### PR TITLE
feat(mcp-client): Add non-blocking tools change notification support

### DIFF
--- a/spring-ai-mcp-core/pom.xml
+++ b/spring-ai-mcp-core/pom.xml
@@ -98,6 +98,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<version>4.2.0</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 

--- a/spring-ai-mcp-core/src/main/java/org/springframework/ai/mcp/client/McpClient.java
+++ b/spring-ai-mcp-core/src/main/java/org/springframework/ai/mcp/client/McpClient.java
@@ -19,8 +19,10 @@ package org.springframework.ai.mcp.client;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+import org.springframework.ai.mcp.spec.McpSchema;
 import org.springframework.ai.mcp.spec.McpSchema.Root;
 import org.springframework.ai.mcp.spec.McpTransport;
 import org.springframework.ai.mcp.util.Assert;
@@ -84,6 +86,8 @@ public class McpClient {
 
 		private List<Supplier<List<Root>>> rootsListProviders = new ArrayList<>();
 
+		private List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers = new ArrayList<>();
+
 		private Builder(McpTransport transport) {
 			Assert.notNull(transport, "Transport must not be null");
 			this.transport = transport;
@@ -110,6 +114,11 @@ public class McpClient {
 			return this;
 		}
 
+		public Builder toolsChangeConsumer(Consumer<List<McpSchema.Tool>> toolsChangeConsumer) {
+			this.toolsChangeConsumers.add(toolsChangeConsumer);
+			return this;
+		}
+
 		/**
 		 * Build a synchronous MCP client.
 		 * @return A new instance of {@link McpSyncClient}
@@ -123,7 +132,8 @@ public class McpClient {
 		 * @return A new instance of {@link McpAsyncClient}
 		 */
 		public McpAsyncClient async() {
-			return new McpAsyncClient(transport, requestTimeout, rootsListProviders, rootsListChangedNotification);
+			return new McpAsyncClient(transport, requestTimeout, rootsListProviders, rootsListChangedNotification,
+					toolsChangeConsumers);
 		}
 
 	}

--- a/spring-ai-mcp-core/src/test/java/org/springframework/ai/mcp/client/AbstractMcpAsyncClientTests.java
+++ b/spring-ai-mcp-core/src/test/java/org/springframework/ai/mcp/client/AbstractMcpAsyncClientTests.java
@@ -183,7 +183,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		var transport = createMcpTransport();
 		List<Supplier<List<Root>>> providers = List.of(() -> List.of(new Root("file:///test/path", "test-root")));
 
-		var client = new McpAsyncClient(transport, TIMEOUT, providers, true);
+		var client = new McpAsyncClient(transport, TIMEOUT, providers, true, List.of());
 
 		assertThatCode(() -> client.initialize().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 


### PR DESCRIPTION
- Add toolsChangeNotificationHandler with non-blocking consumer execution using boundedElastic scheduler
- Add toolsChangeConsumer builder method to McpClient for easy configuration
- Add comprehensive test coverage for tools change notifications
- Update documentation with tools change notification features and examples

The implementation ensures consumers are executed non-blockingly on the boundedElastic scheduler, preventing performance impact from blocking implementations while maintaining proper error handling and logging.

Part of #20