### PR TITLE
feat: Add resources and prompts change notification support

### DIFF
--- a/spring-ai-mcp-core/src/main/java/org/springframework/ai/mcp/client/McpClient.java
+++ b/spring-ai-mcp-core/src/main/java/org/springframework/ai/mcp/client/McpClient.java
@@ -88,6 +88,10 @@ public class McpClient {
 
 		private List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers = new ArrayList<>();
 
+		private List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers = new ArrayList<>();
+
+		private List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers = new ArrayList<>();
+
 		private Builder(McpTransport transport) {
 			Assert.notNull(transport, "Transport must not be null");
 			this.transport = transport;
@@ -119,6 +123,16 @@ public class McpClient {
 			return this;
 		}
 
+		public Builder resourcesChangeConsumer(Consumer<List<McpSchema.Resource>> resourcesChangeConsumer) {
+			this.resourcesChangeConsumers.add(resourcesChangeConsumer);
+			return this;
+		}
+
+		public Builder promptsChangeConsumer(Consumer<List<McpSchema.Prompt>> promptsChangeConsumer) {
+			this.promptsChangeConsumers.add(promptsChangeConsumer);
+			return this;
+		}
+
 		/**
 		 * Build a synchronous MCP client.
 		 * @return A new instance of {@link McpSyncClient}
@@ -133,7 +147,7 @@ public class McpClient {
 		 */
 		public McpAsyncClient async() {
 			return new McpAsyncClient(transport, requestTimeout, rootsListProviders, rootsListChangedNotification,
-					toolsChangeConsumers);
+					toolsChangeConsumers, resourcesChangeConsumers, promptsChangeConsumers);
 		}
 
 	}

--- a/spring-ai-mcp-core/src/test/java/org/springframework/ai/mcp/client/AbstractMcpAsyncClientTests.java
+++ b/spring-ai-mcp-core/src/test/java/org/springframework/ai/mcp/client/AbstractMcpAsyncClientTests.java
@@ -183,7 +183,7 @@ public abstract class AbstractMcpAsyncClientTests {
 		var transport = createMcpTransport();
 		List<Supplier<List<Root>>> providers = List.of(() -> List.of(new Root("file:///test/path", "test-root")));
 
-		var client = new McpAsyncClient(transport, TIMEOUT, providers, true, List.of());
+		var client = McpClient.using(transport).requestTimeout(TIMEOUT).rootsListProvider(providers.get(0)).async();
 
 		assertThatCode(() -> client.initialize().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 


### PR DESCRIPTION
- Add resourcesChangeNotificationHandler and promptsChangeNotificationHandler with non-blocking execution
- Add builder methods for resources and prompts change consumers
- Add test coverage for all notification handlers
- Update documentation to cover all three notification types (tools, resources, prompts)
- Consolidate notification documentation under unified Change Notifications section
- Ensure consistent non-blocking behavior using boundedElastic scheduler

All notification handlers follow the same pattern of non-blocking execution and error handling, providing a consistent approach to change notifications across the system.

Resolves #20