### PR TITLE
Fix potential NullPointerException in toolsListRequestHandler

### DIFF
--- a/mcp/src/main/java/org/springframework/ai/mcp/server/McpAsyncServer.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/server/McpAsyncServer.java
@@ -249,7 +249,12 @@ public class McpAsyncServer {
 				return toolRegistration.tool();
 			}).toList();
 
-			logger.info("Client tools list request - Cursor: {}", request.cursor());
+			String cursorInfo = Optional.ofNullable(request)
+				.map(McpSchema.PaginatedRequest::cursor)
+				.map(cursor -> "Cursor: " + cursor)
+				.orElse("No request");
+
+			logger.info("Client tools list request - {}", cursorInfo);
 			return Mono.just(new McpSchema.ListToolsResult(tools, null));
 		};
 	}


### PR DESCRIPTION
In certain scenarios, the 'params' argument could be null, resulting in a null 'request' object. This could lead to a NullPointerException when attempting to access request.cursor().