### PR TITLE
feat(McpAsyncServer): Add non-blocking execution for tools and resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Add the following dependencies to your Maven project:
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>mcp</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- For Spring AI integration -->
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>spring-ai-mcp</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/mcp-docs/src/main/antora/modules/ROOT/pages/mcp.adoc
+++ b/mcp-docs/src/main/antora/modules/ROOT/pages/mcp.adoc
@@ -25,7 +25,7 @@ Add the following dependency to your Maven project:
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>mcp</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ----
 

--- a/mcp-docs/src/main/antora/modules/ROOT/pages/overview.adoc
+++ b/mcp-docs/src/main/antora/modules/ROOT/pages/overview.adoc
@@ -40,7 +40,7 @@ Maven::
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>mcp</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ----
 +
@@ -50,7 +50,7 @@ Maven::
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>spring-ai-mcp</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ----
 +

--- a/mcp-docs/src/main/antora/modules/ROOT/pages/spring-mcp.adoc
+++ b/mcp-docs/src/main/antora/modules/ROOT/pages/spring-mcp.adoc
@@ -36,6 +36,6 @@ To use this module, add the following dependency to your Maven project:
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>spring-ai-mcp</artifactId>
-    <version>0.4.0-SNAPSHOT</version>
+    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ----

--- a/mcp/src/main/java/org/springframework/ai/mcp/server/McpAsyncServer.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/server/McpAsyncServer.java
@@ -374,9 +374,9 @@ public class McpAsyncServer {
 				return Mono.<Object>error(new McpError("Tool not found: " + callToolRequest.name()));
 			}
 
-			CallToolResult callResponse = toolRegistration.get().call().apply(callToolRequest.arguments());
-
-			return Mono.just(callResponse);
+			return Mono.fromCallable(() -> toolRegistration.get().call().apply(callToolRequest.arguments()))
+				.map(result -> (Object) result)
+				.subscribeOn(Schedulers.boundedElastic());
 		};
 	}
 
@@ -462,7 +462,9 @@ public class McpAsyncServer {
 					});
 			var resourceUri = resourceRequest.uri();
 			if (this.resources.containsKey(resourceUri)) {
-				return Mono.just(this.resources.get(resourceUri).readHandler().apply(resourceRequest));
+				return Mono.fromCallable(() -> this.resources.get(resourceUri).readHandler().apply(resourceRequest))
+					.map(result -> (Object) result)
+					.subscribeOn(Schedulers.boundedElastic());
 			}
 			return Mono.error(new McpError("Resource not found: " + resourceUri));
 		};
@@ -558,7 +560,10 @@ public class McpAsyncServer {
 
 			// Implement prompt retrieval logic here
 			if (this.prompts.containsKey(promptRequest.name())) {
-				return Mono.just(this.prompts.get(promptRequest.name()).promptHandler().apply(promptRequest));
+				return Mono
+					.fromCallable(() -> this.prompts.get(promptRequest.name()).promptHandler().apply(promptRequest))
+					.map(result -> (Object) result)
+					.subscribeOn(Schedulers.boundedElastic());
 			}
 
 			return Mono.error(new McpError("Prompt not found: " + promptRequest.name()));

--- a/spring-ai-mcp-sample/README.md
+++ b/spring-ai-mcp-sample/README.md
@@ -28,7 +28,7 @@ The server can be started in two transport modes, controlled by the `transport.m
 ### Stdio Mode (Default)
 
 ```bash
-java -Dtransport.mode=stdio -jar target/spring-ai-mcp-sample-0.4.0-SNAPSHOT.jar
+java -Dtransport.mode=stdio -jar target/spring-ai-mcp-sample-0.5.0-SNAPSHOT.jar
 ```
 
 The Stdio mode server is automatically started by the client - no explicit server startup is needed.
@@ -38,7 +38,7 @@ In Stdio mode the server must not emit any messages/logs to the console (e.g. st
 
 ### SSE Mode
 ```bash
-java -Dtransport.mode=sse -jar target/spring-ai-mcp-sample-0.4.0-SNAPSHOT.jar
+java -Dtransport.mode=sse -jar target/spring-ai-mcp-sample-0.5.0-SNAPSHOT.jar
 ```
 
 ## Sample Clients
@@ -49,7 +49,7 @@ The project includes example clients for both transport modes:
 ```java
 var stdioParams = ServerParameters.builder("java")
     .args("-Dtransport.mode=stdio", "-jar",
-            "target/spring-ai-mcp-sample-0.4.0-SNAPSHOT.jar")
+            "target/spring-ai-mcp-sample-0.5.0-SNAPSHOT.jar")
     .build();
 
 var transport = new StdioClientTransport(stdioParams);

--- a/spring-ai-mcp-sample/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
+++ b/spring-ai-mcp-sample/src/main/java/org/springframework/ai/mcp/sample/client/ClientStdio.java
@@ -28,7 +28,7 @@ public class ClientStdio {
 
 		var stdioParams = ServerParameters.builder("java")
 			.args("-Dtransport.mode=stdio", "-jar",
-					"spring-ai-mcp-sample/target/spring-ai-mcp-sample-0.4.0-SNAPSHOT.jar")
+					"spring-ai-mcp-sample/target/spring-ai-mcp-sample-0.5.0-SNAPSHOT.jar")
 			.build();
 
 		var transport = new StdioClientTransport(stdioParams);


### PR DESCRIPTION
- Execute tool calls, resource reads and prompt handling in a non-blocking manner using Schedulers.boundedElastic(). This prevents blocking operations from impacting server responsiveness.
- Added integration tests to verify non-blocking behavior with tools that make HTTP calls to external services.

Related to #48
This is  a temp patch until #48 is resolved properly.