### PR TITLE
refactor(transport): Replace SseEmitter with queue-based SSE implementation in WebMvc transport

### DIFF
--- a/mcp-transport/mcp-webflux-sse-transport/pom.xml
+++ b/mcp-transport/mcp-webflux-sse-transport/pom.xml
@@ -108,6 +108,13 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit-jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 

--- a/mcp-transport/mcp-webmvc-sse-transport/src/test/java/org/springframework/ai/mcp/server/WebMvcSseIntegrationTests.java
+++ b/mcp-transport/mcp-webmvc-sse-transport/src/test/java/org/springframework/ai/mcp/server/WebMvcSseIntegrationTests.java
@@ -1,0 +1,524 @@
+/*
+ * Copyright 2024 - 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.ai.mcp.server;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.catalina.Context;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.LifecycleState;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.test.StepVerifier;
+
+import org.springframework.ai.mcp.client.McpClient;
+import org.springframework.ai.mcp.client.transport.HttpClientSseClientTransport;
+import org.springframework.ai.mcp.server.McpServer.ToolRegistration;
+import org.springframework.ai.mcp.server.transport.WebMvcSseServerTransport;
+import org.springframework.ai.mcp.spec.McpError;
+import org.springframework.ai.mcp.spec.McpSchema;
+import org.springframework.ai.mcp.spec.McpSchema.CallToolResult;
+import org.springframework.ai.mcp.spec.McpSchema.ClientCapabilities;
+import org.springframework.ai.mcp.spec.McpSchema.CreateMessageRequest;
+import org.springframework.ai.mcp.spec.McpSchema.CreateMessageResult;
+import org.springframework.ai.mcp.spec.McpSchema.InitializeResult;
+import org.springframework.ai.mcp.spec.McpSchema.Role;
+import org.springframework.ai.mcp.spec.McpSchema.Root;
+import org.springframework.ai.mcp.spec.McpSchema.ServerCapabilities;
+import org.springframework.ai.mcp.spec.McpSchema.Tool;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.context.support.AnnotationConfigWebApplicationContext;
+import org.springframework.web.servlet.DispatcherServlet;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+
+public class WebMvcSseIntegrationTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(WebMvcSseIntegrationTests.class);
+
+	private static final int PORT = 8183;
+
+	private static final String MESSAGE_ENDPOINT = "/mcp/message";
+
+	private WebMvcSseServerTransport mcpServerTransport;
+
+	McpClient.Builder clientBuilder;
+
+	@Configuration
+	@EnableWebMvc
+	static class TestConfig {
+
+		@Bean
+		public WebMvcSseServerTransport webMvcSseServerTransport() {
+			return new WebMvcSseServerTransport(new ObjectMapper(), MESSAGE_ENDPOINT);
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> routerFunction(WebMvcSseServerTransport transport) {
+			return transport.getRouterFunction();
+		}
+
+	}
+
+	private Tomcat tomcat;
+
+	private AnnotationConfigWebApplicationContext appContext;
+
+	@BeforeEach
+	public void before() {
+
+		// Set up Tomcat first
+		tomcat = new Tomcat();
+		tomcat.setPort(PORT);
+
+		// Set Tomcat base directory to java.io.tmpdir to avoid permission issues
+		String baseDir = System.getProperty("java.io.tmpdir");
+		tomcat.setBaseDir(baseDir);
+
+		// Use the same directory for document base
+		Context context = tomcat.addContext("", baseDir);
+
+		// Create and configure Spring WebMvc context
+		appContext = new AnnotationConfigWebApplicationContext();
+		appContext.register(TestConfig.class);
+		appContext.setServletContext(context.getServletContext());
+		appContext.refresh();
+
+		// Get the transport from Spring context
+		mcpServerTransport = appContext.getBean(WebMvcSseServerTransport.class);
+
+		// Create DispatcherServlet with our Spring context
+		DispatcherServlet dispatcherServlet = new DispatcherServlet(appContext);
+		// dispatcherServlet.setThrowExceptionIfNoHandlerFound(true);
+
+		// Add servlet to Tomcat and get the wrapper
+		var wrapper = Tomcat.addServlet(context, "dispatcherServlet", dispatcherServlet);
+		wrapper.setLoadOnStartup(1);
+		wrapper.setAsyncSupported(true);
+		context.addServletMappingDecoded("/*", "dispatcherServlet");
+
+		try {
+			// Configure and start the connector with async support
+			var connector = tomcat.getConnector();
+			connector.setAsyncTimeout(3000); // 3 seconds timeout for async requests
+			tomcat.start();
+			assertThat(tomcat.getServer().getState() == LifecycleState.STARTED);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Failed to start Tomcat", e);
+		}
+
+		this.clientBuilder = McpClient.using(new HttpClientSseClientTransport("http://localhost:" + PORT));
+	}
+
+	@AfterEach
+	public void after() {
+		if (mcpServerTransport != null) {
+			mcpServerTransport.closeGracefully().block();
+		}
+		if (appContext != null) {
+			appContext.close();
+		}
+		if (tomcat != null) {
+			try {
+				tomcat.stop();
+				tomcat.destroy();
+			}
+			catch (LifecycleException e) {
+				throw new RuntimeException("Failed to stop Tomcat", e);
+			}
+		}
+	}
+
+	// ---------------------------------------
+	// Sampling Tests
+	// ---------------------------------------
+	@Test
+	void testCreateMessageWithoutInitialization() {
+		var mcpAsyncServer = McpServer.using(mcpServerTransport).serverInfo("test-server", "1.0.0").async();
+
+		var messages = List
+			.of(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Test message")));
+		var modelPrefs = new McpSchema.ModelPreferences(List.of(), 1.0, 1.0, 1.0);
+
+		var request = new McpSchema.CreateMessageRequest(messages, modelPrefs, null,
+				McpSchema.CreateMessageRequest.ContextInclusionStrategy.NONE, null, 100, List.of(), Map.of());
+
+		StepVerifier.create(mcpAsyncServer.createMessage(request)).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(McpError.class)
+				.hasMessage("Client must be initialized. Call the initialize method first!");
+		});
+	}
+
+	@Test
+	void testCreateMessageWithoutSamplingCapabilities() {
+
+		var mcpAsyncServer = McpServer.using(mcpServerTransport).serverInfo("test-server", "1.0.0").async();
+
+		var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0")).sync();
+
+		InitializeResult initResult = client.initialize();
+		assertThat(initResult).isNotNull();
+
+		var messages = List
+			.of(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Test message")));
+		var modelPrefs = new McpSchema.ModelPreferences(List.of(), 1.0, 1.0, 1.0);
+
+		var request = new McpSchema.CreateMessageRequest(messages, modelPrefs, null,
+				McpSchema.CreateMessageRequest.ContextInclusionStrategy.NONE, null, 100, List.of(), Map.of());
+
+		StepVerifier.create(mcpAsyncServer.createMessage(request)).verifyErrorSatisfies(error -> {
+			assertThat(error).isInstanceOf(McpError.class)
+				.hasMessage("Client must be configured with sampling capabilities");
+		});
+	}
+
+	@Test
+	void testCreateMessageSuccess() throws InterruptedException {
+
+		var mcpAsyncServer = McpServer.using(mcpServerTransport).serverInfo("test-server", "1.0.0").async();
+
+		Function<CreateMessageRequest, CreateMessageResult> samplingHandler = request -> {
+			assertThat(request.messages()).hasSize(1);
+			assertThat(request.messages().get(0).content()).isInstanceOf(McpSchema.TextContent.class);
+
+			return new CreateMessageResult(Role.USER, new McpSchema.TextContent("Test message"), "MockModelName",
+					CreateMessageResult.StopReason.STOP_SEQUENCE);
+		};
+
+		var client = clientBuilder.clientInfo(new McpSchema.Implementation("Sample client", "0.0.0"))
+			.capabilities(ClientCapabilities.builder().sampling().build())
+			.sampling(samplingHandler)
+			.sync();
+
+		InitializeResult initResult = client.initialize();
+		assertThat(initResult).isNotNull();
+
+		var messages = List
+			.of(new McpSchema.SamplingMessage(McpSchema.Role.USER, new McpSchema.TextContent("Test message")));
+		var modelPrefs = new McpSchema.ModelPreferences(List.of(), 1.0, 1.0, 1.0);
+
+		var request = new McpSchema.CreateMessageRequest(messages, modelPrefs, null,
+				McpSchema.CreateMessageRequest.ContextInclusionStrategy.NONE, null, 100, List.of(), Map.of());
+
+		StepVerifier.create(mcpAsyncServer.createMessage(request)).consumeNextWith(result -> {
+			assertThat(result).isNotNull();
+			assertThat(result.role()).isEqualTo(Role.USER);
+			assertThat(result.content()).isInstanceOf(McpSchema.TextContent.class);
+			assertThat(((McpSchema.TextContent) result.content()).text()).isEqualTo("Test message");
+			assertThat(result.model()).isEqualTo("MockModelName");
+			assertThat(result.stopReason()).isEqualTo(CreateMessageResult.StopReason.STOP_SEQUENCE);
+		}).verifyComplete();
+	}
+
+	// ---------------------------------------
+	// Roots Tests
+	// ---------------------------------------
+	@Test
+	void testRootsSuccess() {
+		List<Root> roots = List.of(new Root("uri1://", "root1"), new Root("uri2://", "root2"));
+
+		AtomicReference<List<Root>> rootsRef = new AtomicReference<>();
+		var mcpServer = McpServer.using(mcpServerTransport)
+			.rootsChangeConsumer(rootsUpdate -> rootsRef.set(rootsUpdate))
+			.sync();
+
+		var mcpClient = clientBuilder.capabilities(ClientCapabilities.builder().roots(true).build())
+			.roots(roots)
+			.sync();
+
+		InitializeResult initResult = mcpClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		assertThat(rootsRef.get()).isNull();
+
+		assertThat(mcpServer.listRoots().roots()).containsAll(roots);
+
+		mcpClient.rootsListChangedNotification();
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef.get()).containsAll(roots);
+		});
+
+		// Remove a root
+		mcpClient.removeRoot(roots.get(0).uri());
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef.get()).containsAll(List.of(roots.get(1)));
+		});
+
+		// Add a new root
+		var root3 = new Root("uri3://", "root3");
+		mcpClient.addRoot(root3);
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef.get()).containsAll(List.of(roots.get(1), root3));
+		});
+
+		mcpClient.close();
+		mcpServer.close();
+	}
+
+	@Test
+	void testRootsWithoutCapability() {
+		var mcpServer = McpServer.using(mcpServerTransport).rootsChangeConsumer(rootsUpdate -> {
+		}).sync();
+
+		// Create client without roots capability
+		// No roots capability
+		var mcpClient = clientBuilder.capabilities(ClientCapabilities.builder().build()).sync();
+
+		InitializeResult initResult = mcpClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		// Attempt to list roots should fail
+		assertThatThrownBy(() -> mcpServer.listRoots().roots()).isInstanceOf(McpError.class)
+			.hasMessage("Roots not supported");
+
+		mcpClient.close();
+		mcpServer.close();
+	}
+
+	@Test
+	void testRootsWithEmptyRootsList() {
+		AtomicReference<List<Root>> rootsRef = new AtomicReference<>();
+		var mcpServer = McpServer.using(mcpServerTransport)
+			.rootsChangeConsumer(rootsUpdate -> rootsRef.set(rootsUpdate))
+			.sync();
+
+		var mcpClient = clientBuilder.capabilities(ClientCapabilities.builder().roots(true).build())
+			.roots(List.of()) // Empty roots list
+			.sync();
+
+		InitializeResult initResult = mcpClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		mcpClient.rootsListChangedNotification();
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef.get()).isEmpty();
+		});
+
+		mcpClient.close();
+		mcpServer.close();
+	}
+
+	@Test
+	void testRootsWithMultipleConsumers() {
+		List<Root> roots = List.of(new Root("uri1://", "root1"));
+
+		AtomicReference<List<Root>> rootsRef1 = new AtomicReference<>();
+		AtomicReference<List<Root>> rootsRef2 = new AtomicReference<>();
+
+		var mcpServer = McpServer.using(mcpServerTransport)
+			.rootsChangeConsumer(rootsUpdate -> rootsRef1.set(rootsUpdate))
+			.rootsChangeConsumer(rootsUpdate -> rootsRef2.set(rootsUpdate))
+			.sync();
+
+		var mcpClient = clientBuilder.capabilities(ClientCapabilities.builder().roots(true).build())
+			.roots(roots)
+			.sync();
+
+		InitializeResult initResult = mcpClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		mcpClient.rootsListChangedNotification();
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef1.get()).containsAll(roots);
+			assertThat(rootsRef2.get()).containsAll(roots);
+		});
+
+		mcpClient.close();
+		mcpServer.close();
+	}
+
+	@Test
+	void testRootsServerCloseWithActiveSubscription() {
+		List<Root> roots = List.of(new Root("uri1://", "root1"));
+
+		AtomicReference<List<Root>> rootsRef = new AtomicReference<>();
+		var mcpServer = McpServer.using(mcpServerTransport)
+			.rootsChangeConsumer(rootsUpdate -> rootsRef.set(rootsUpdate))
+			.sync();
+
+		var mcpClient = clientBuilder.capabilities(ClientCapabilities.builder().roots(true).build())
+			.roots(roots)
+			.sync();
+
+		InitializeResult initResult = mcpClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		mcpClient.rootsListChangedNotification();
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef.get()).containsAll(roots);
+		});
+
+		// Close server while subscription is active
+		mcpServer.close();
+
+		// Verify client can handle server closure gracefully
+		mcpClient.close();
+	}
+
+	// ---------------------------------------
+	// Tools Tests
+	// ---------------------------------------
+
+	String emptyJsonSchema = """
+			{
+				"$schema": "http://json-schema.org/draft-07/schema#",
+				"type": "object",
+				"properties": {}
+			}
+			""";
+
+	@Test
+	void testToolCallSuccess() {
+
+		var callResponse = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
+		ToolRegistration tool1 = new ToolRegistration(new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema),
+				request -> {
+					// perform a blocking call to a remote service
+					String response = RestClient.create()
+						.get()
+						.uri("https://github.com/spring-projects-experimental/spring-ai-mcp/blob/main/README.md")
+						.retrieve()
+						.body(String.class);
+					assertThat(response).isNotBlank();
+					return callResponse;
+				});
+
+		var mcpServer = McpServer.using(mcpServerTransport)
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool1)
+			.sync();
+
+		var mcpClient = clientBuilder.sync();
+
+		InitializeResult initResult = mcpClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		assertThat(mcpClient.listTools().tools()).contains(tool1.tool());
+
+		CallToolResult response = mcpClient.callTool(new McpSchema.CallToolRequest("tool1", Map.of()));
+
+		assertThat(response).isNotNull();
+		assertThat(response).isEqualTo(callResponse);
+
+		mcpClient.close();
+		mcpServer.close();
+	}
+
+	@Test
+	void testToolListChangeHandlingSuccess() {
+
+		var callResponse = new McpSchema.CallToolResult(List.of(new McpSchema.TextContent("CALL RESPONSE")), null);
+		ToolRegistration tool1 = new ToolRegistration(new McpSchema.Tool("tool1", "tool1 description", emptyJsonSchema),
+				request -> {
+					// perform a blocking call to a remote service
+					String response = RestClient.create()
+						.get()
+						.uri("https://github.com/spring-projects-experimental/spring-ai-mcp/blob/main/README.md")
+						.retrieve()
+						.body(String.class);
+					assertThat(response).isNotBlank();
+					return callResponse;
+				});
+
+		var mcpServer = McpServer.using(mcpServerTransport)
+			.capabilities(ServerCapabilities.builder().tools(true).build())
+			.tools(tool1)
+			.sync();
+
+		AtomicReference<List<Tool>> rootsRef = new AtomicReference<>();
+		var mcpClient = clientBuilder.toolsChangeConsumer(toolsUpdate -> {
+			// perform a blocking call to a remote service
+			String response = RestClient.create()
+				.get()
+				.uri("https://github.com/spring-projects-experimental/spring-ai-mcp/blob/main/README.md")
+				.retrieve()
+				.body(String.class);
+			assertThat(response).isNotBlank();
+			rootsRef.set(toolsUpdate);
+		}).sync();
+
+		InitializeResult initResult = mcpClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		assertThat(rootsRef.get()).isNull();
+
+		assertThat(mcpClient.listTools().tools()).contains(tool1.tool());
+
+		mcpServer.notifyToolsListChanged();
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef.get()).containsAll(List.of(tool1.tool()));
+		});
+
+		// Remove a tool
+		mcpServer.removeTool("tool1");
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef.get()).isEmpty();
+		});
+
+		// Add a new tool
+		ToolRegistration tool2 = new ToolRegistration(new McpSchema.Tool("tool2", "tool2 description", emptyJsonSchema),
+				request -> callResponse);
+
+		mcpServer.addTool(tool2);
+
+		await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+			assertThat(rootsRef.get()).containsAll(List.of(tool2.tool()));
+		});
+
+		mcpClient.close();
+		mcpServer.close();
+	}
+
+	@Test
+	void testInitialize() {
+
+		var mcpServer = McpServer.using(mcpServerTransport).sync();
+
+		var mcpClient = clientBuilder.sync();
+
+		InitializeResult initResult = mcpClient.initialize();
+		assertThat(initResult).isNotNull();
+
+		mcpClient.close();
+		mcpServer.close();
+	}
+
+}

--- a/mcp-transport/mcp-webmvc-sse-transport/src/test/resources/logback.xml
+++ b/mcp-transport/mcp-webmvc-sse-transport/src/test/resources/logback.xml
@@ -9,13 +9,16 @@
     </appender>
 
     <!-- Main MCP package -->
-    <logger name="org.springframework.ai.mcp" level="INFO"/>
+    <logger name="org.springframework.ai.mcp" level="DEBUG"/>
 
     <!-- Client packages -->
-    <logger name="org.springframework.ai.mcp.client" level="INFO"/>
+    <logger name="org.springframework.ai.mcp.client" level="DEBUG"/>
+
+    <!-- Server transport package -->
+    <logger name="org.springframework.ai.mcp.server.transport" level="DEBUG"/>
 
     <!-- Spec package -->
-    <logger name="org.springframework.ai.mcp.spec" level="INFO"/>
+    <logger name="org.springframework.ai.mcp.spec" level="DEBUG"/>
 
     <!-- Root logger -->
     <root level="INFO">

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/transport/HttpClientSseClientTransport.java
@@ -139,7 +139,9 @@ public class HttpClientSseClientTransport implements ClientMcpTransport {
 		}
 
 		try {
-			closeLatch.await(10, TimeUnit.SECONDS);
+			if (!closeLatch.await(10, TimeUnit.SECONDS)) {
+				return Mono.error(new McpError("Failed to wait for the message endpoint"));
+			}
 		}
 		catch (InterruptedException e) {
 			return Mono.error(new McpError("Failed to wait for the message endpoint"));

--- a/mcp/src/test/java/org/springframework/ai/mcp/attic/SSEClient.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/attic/SSEClient.java
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-package org.springframework.ai.mcp.client.transport;
+package org.springframework.ai.mcp.attic;
 
 /**
  * @author Christian Tzolov

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
 		<org.maven.antora-version>1.0.0-alpha.4</org.maven.antora-version>
 		<io.spring.maven.antora-version>0.0.4</io.spring.maven.antora-version>
 		<asciidoctorj-pdf.version>1.6.2</asciidoctorj-pdf.version>
+		<junit-jupiter.version>5.10.5</junit-jupiter.version>
 	</properties>
 
 	<modules>
@@ -105,6 +106,7 @@
 		<module>spring-ai-mcp</module>
 		<module>mcp-docs</module>
 		<module>mcp-test</module>
+		<!-- <module>samples/spring-ai-mcp-webmvc-sample</module> -->
 	</modules>
 
 	<build>

--- a/samples/spring-ai-mcp-webmvc-sample/pom.xml
+++ b/samples/spring-ai-mcp-webmvc-sample/pom.xml
@@ -27,6 +27,13 @@
             <artifactId>mcp-webmvc-sse-transport</artifactId>
             <version>${spring-ai-mcp.version}</version>
         </dependency>
+        
+        <!-- Used only for the client webflux transport -->
+        <dependency>
+            <groupId>org.springframework.experimental</groupId>
+            <artifactId>mcp-webflux-sse-transport</artifactId>
+            <version>${spring-ai-mcp.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.experimental</groupId>
             <artifactId>spring-ai-mcp</artifactId>

--- a/samples/spring-ai-mcp-webmvc-sample/src/main/java/org/springframework/ai/mcp/sample/webmvc/client/ClientWebFluxSse.java
+++ b/samples/spring-ai-mcp-webmvc-sample/src/main/java/org/springframework/ai/mcp/sample/webmvc/client/ClientWebFluxSse.java
@@ -1,0 +1,32 @@
+/*
+* Copyright 2024 - 2024 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package org.springframework.ai.mcp.sample.webmvc.client;
+
+import org.springframework.ai.mcp.client.transport.WebFluxSseClientTransport;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * @author Christian Tzolov
+ */
+public class ClientWebFluxSse {
+
+	public static void main(String[] args) {
+		var transport = new WebFluxSseClientTransport(WebClient.builder().baseUrl("http://localhost:8080"));
+
+		new SampleClient(transport).run();
+	}
+
+}

--- a/samples/spring-ai-mcp-webmvc-sample/src/main/java/org/springframework/ai/mcp/sample/webmvc/server/McpMvcServerApplication.java
+++ b/samples/spring-ai-mcp-webmvc-sample/src/main/java/org/springframework/ai/mcp/sample/webmvc/server/McpMvcServerApplication.java
@@ -4,10 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class McpServerApplication {
+public class McpMvcServerApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(McpServerApplication.class, args);
+		SpringApplication.run(McpMvcServerApplication.class, args);
 	}
 
 }

--- a/samples/spring-ai-mcp-webmvc-sample/src/main/java/org/springframework/ai/mcp/sample/webmvc/server/McpServerConfig.java
+++ b/samples/spring-ai-mcp-webmvc-sample/src/main/java/org/springframework/ai/mcp/sample/webmvc/server/McpServerConfig.java
@@ -31,22 +31,12 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.function.RouterFunction;
 import org.springframework.web.servlet.function.ServerResponse;
 
 @Configuration
 @EnableWebMvc
 public class McpServerConfig implements WebMvcConfigurer {
-
-	@Override
-	public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
-		MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
-		converter.setSupportedMediaTypes(List.of(org.springframework.http.MediaType.APPLICATION_JSON,
-				org.springframework.http.MediaType.TEXT_EVENT_STREAM));
-		converters.add(converter);
-	}
 
 	private static final Logger logger = LoggerFactory.getLogger(McpServerConfig.class);
 

--- a/samples/spring-ai-mcp-webmvc-sample/src/main/resources/application.properties
+++ b/samples/spring-ai-mcp-webmvc-sample/src/main/resources/application.properties
@@ -1,8 +1,8 @@
-# spring.main.web-application-type=none
+spring.main.web-application-type=SERVLET
 
 # NOTE: You must disable the banner and the console logging 
 # to allow the STDIO transport to work !!!
 spring.main.banner-mode=off
-# logging.pattern.console=
+logging.pattern.console=
 
 transport.mode=sse


### PR DESCRIPTION
Replaces Spring's SseEmitter with a custom BlockingQueue-based SSE implementation in WebMvcSseServerTransport for improved event delivery control and connection management.

The new implementation:
- Uses BlockingQueue for reliable event queuing and delivery
- Adds proper session management with dedicated SSEEvent record
- Improves error handling and timeout management
- Adds comprehensive integration tests

Resolves #57