### PR TITLE
Add Bill of Materials (BOM) for dependency management

### DIFF
--- a/mcp-bom/pom.xml
+++ b/mcp-bom/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.experimental</groupId>
+        <artifactId>mcp-parent</artifactId>
+        <version>0.5.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>mcp-bom</artifactId>
+    <packaging>pom</packaging>
+    <name>Spring AI MCP BOM</name>
+    <description>Spring AI MCP Bill of Materials</description>
+
+    <properties>
+        <main.basedir>${basedir}/..</main.basedir>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Core MCP -->
+            <dependency>
+                <groupId>org.springframework.experimental</groupId>
+                <artifactId>mcp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- MCP Test -->
+            <dependency>
+                <groupId>org.springframework.experimental</groupId>
+                <artifactId>mcp-test</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- MCP Transport - WebFlux SSE -->
+            <dependency>
+                <groupId>org.springframework.experimental</groupId>
+                <artifactId>mcp-webflux-sse-transport</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- MCP Transport - WebMVC SSE -->
+            <dependency>
+                <groupId>org.springframework.experimental</groupId>
+                <artifactId>mcp-webmvc-sse-transport</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <!-- Spring AI MCP -->
+            <dependency>
+                <groupId>org.springframework.experimental</groupId>
+                <artifactId>spring-ai-mcp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/mcp-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/mcp-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -1,5 +1,4 @@
 * xref:overview.adoc[Overview]
+** xref:dependency-management.adoc[Dependency Management]
 * xref:mcp.adoc[MCP Java SDK]
 * xref:spring-mcp.adoc[Spring AI MCP]
-// ** xref:concepts.adoc[AI Concepts]
-// * xref:getting-started.adoc[Getting Started]

--- a/mcp-docs/src/main/antora/modules/ROOT/pages/dependency-management.adoc
+++ b/mcp-docs/src/main/antora/modules/ROOT/pages/dependency-management.adoc
@@ -1,0 +1,109 @@
+[[dependency-management]]
+= Dependency Management
+
+[[mcp-bom]]
+== Bill of Materials (BOM)
+
+The Bill of Materials (BOM) declares the recommended versions of all the dependencies used by a given release.
+Using the BOM from your application’s build script avoids the need for you to specify and maintain the dependency versions yourself.
+Instead, the version of the BOM you’re using determines the utilized dependency versions.
+It also ensures that you’re using supported and tested versions of the dependencies by default, unless you choose to override them.
+
+Add the BOM to your project:
+
+[tabs]
+======
+Maven::
++
+[source,xml,indent=0,subs="verbatim,quotes"]
+----
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.experimental</groupId>
+            <artifactId>mcp-bom</artifactId>
+            <version>0.5.0-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+----
+
+Gradle::
++
+[source,groovy,indent=0,subs="verbatim,quotes"]
+----
+dependencies {
+  implementation platform("org.springframework.experimental:mcp-bom:0.5.0-SNAPSHOT")
+  // Replace the following with the starter dependencies of specific modules you wish to use
+  //...
+}
+----
+Gradle users can also use the Spring AI MCP BOM by leveraging Gradle (5.0+) native support for declaring dependency constraints using a Maven BOM.
+This is implemented by adding a 'platform' dependency handler method to the dependencies section of your Gradle build script.
+As shown in the snippet below this can then be followed by version-less declarations of the Starter Dependencies for the one or more spring-ai modules you wish to use, e.g. spring-ai-openai.
+======
+
+[[dependencies]]
+== Available Dependencies
+
+The following dependencies are available and managed by the BOM:
+
+=== Core Dependencies
+
+* `org.springframework.experimental:mcp` - Core MCP library providing the base functionality and APIs for Model Context Protocol implementation.
+* `org.springframework.experimental:spring-ai-mcp` - Spring AI integration with MCP, providing Spring-specific features and utilities.
+
+=== Transport Dependencies
+
+* `org.springframework.experimental:mcp-webflux-sse-transport` - WebFlux-based Server-Sent Events (SSE) transport implementation for reactive applications.
+* `org.springframework.experimental:mcp-webmvc-sse-transport` - WebMVC-based Server-Sent Events (SSE) transport implementation for servlet-based applications.
+
+=== Testing Dependencies
+
+* `org.springframework.experimental:mcp-test` - Testing utilities and support for MCP-based applications.
+
+[[repositories]]
+=== Milestone and Snapshot Repositories
+
+To use the Milestone and Snapshot version, you need to add references to the Spring Milestone and/or Snapshot repositories in your build file.
+Add the following repository definitions to your Maven or Gradle build file:
+
+[tabs]
+======
+Maven::
++
+[source,xml,indent=0,subs="verbatim,quotes"]
+----
+  <repositories>
+    <repository>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>spring-snapshots</id>
+      <name>Spring Snapshots</name>
+      <url>https://repo.spring.io/snapshot</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+  </repositories>
+----
+
+Gradle::
++
+[source,groovy,indent=0,subs="verbatim,quotes"]
+----
+repositories {
+  mavenCentral()
+  maven { url 'https://repo.spring.io/milestone' }
+  maven { url 'https://repo.spring.io/snapshot' }
+}
+----
+======

--- a/mcp-docs/src/main/antora/modules/ROOT/pages/mcp.adoc
+++ b/mcp-docs/src/main/antora/modules/ROOT/pages/mcp.adoc
@@ -35,7 +35,6 @@ The core MCP functionality:
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>mcp</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ----
 +
@@ -48,14 +47,12 @@ For HTTP SSE transport implementations, add one of the following dependencies
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>mcp-webflux-sse-transport</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Spring WebMVC-based SSE server transport -->
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>mcp-webmvc-sse-transport</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -83,6 +80,7 @@ implementation 'org.springframework.experimental:mcp-webmvc-sse-transport'
 ----
 ======
 
+Reffer to the xref:dependency-management.adoc[Dependency Management] page for more information.
 
 == Architecture
 

--- a/mcp-docs/src/main/antora/modules/ROOT/pages/overview.adoc
+++ b/mcp-docs/src/main/antora/modules/ROOT/pages/overview.adoc
@@ -37,7 +37,7 @@ Spring integration features:
 * Spring-friendly MCP client abstractions
 * Auto-configurations (WIP)
 
-== Installation
+== Getting Started
 
 [tabs]
 ======
@@ -48,29 +48,25 @@ Maven::
 <!-- Core MCP -->
 <dependency>
     <groupId>org.springframework.experimental</groupId>
-    <artifactId>mcp</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
+    <artifactId>mcp</artifactId>    
 </dependency>
 
 <!-- Optional: WebFlux SSE transport -->
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>mcp-webflux-sse-transport</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Optional: WebMVC SSE transport -->
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>mcp-webmvc-sse-transport</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Optional: Spring AI integration -->
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>spring-ai-mcp</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ----
 +
@@ -106,6 +102,8 @@ repositories {
 }
 ----
 ======
+
+Reffer to the xref:dependency-management.adoc[Dependency Management] page for more information.
 
 == Examples
 

--- a/mcp-docs/src/main/antora/modules/ROOT/pages/spring-mcp.adoc
+++ b/mcp-docs/src/main/antora/modules/ROOT/pages/spring-mcp.adoc
@@ -118,9 +118,10 @@ To use this module, add the following dependency to your Maven project:
 <dependency>
     <groupId>org.springframework.experimental</groupId>
     <artifactId>spring-ai-mcp</artifactId>
-    <version>0.5.0-SNAPSHOT</version>
 </dependency>
 ----
+
+Reffer to the xref:dependency-management.adoc[Dependency Management] page for more information.
 
 === Example: Creating an MCP Tool Server with Spring AI Functions
 

--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
 	</properties>
 
 	<modules>
+		<module>mcp-bom</module>
 		<module>mcp</module>
 		<module>mcp-transport/mcp-webflux-sse-transport</module>
 		<module>mcp-transport/mcp-webmvc-sse-transport</module>


### PR DESCRIPTION
Introduces a new mcp-bom module to simplify dependency version management across Spring AI MCP projects. The BOM allows users to import a single dependency that manages versions of all MCP components, ensuring version compatibility and reducing maintenance overhead.

- Adds mcp-bom module with managed versions for all Spring AI MCP dependencies
- Provides centralized version control through a single BOM import
- Removes explicit version declarations from documentation examples
- Adds dependency management documentation and updates existing docs to reference the new BOM

Resolves #59