### PR TITLE
feat: Make SSE endpoint configurable in server transports

### DIFF
--- a/mcp-transport/mcp-webflux-sse-transport/src/main/java/org/springframework/ai/mcp/client/transport/WebFluxSseClientTransport.java
+++ b/mcp-transport/mcp-webflux-sse-transport/src/main/java/org/springframework/ai/mcp/client/transport/WebFluxSseClientTransport.java
@@ -72,31 +72,31 @@ import org.springframework.web.reactive.function.client.WebClient;
  */
 public class WebFluxSseClientTransport implements ClientMcpTransport {
 
-	private final static Logger logger = LoggerFactory.getLogger(WebFluxSseClientTransport.class);
+	private static final Logger logger = LoggerFactory.getLogger(WebFluxSseClientTransport.class);
 
 	/**
 	 * Event type for JSON-RPC messages received through the SSE connection. The server
 	 * sends messages with this event type to transmit JSON-RPC protocol data.
 	 */
-	private final static String MESSAGE_EVENT_TYPE = "message";
+	private static final String MESSAGE_EVENT_TYPE = "message";
 
 	/**
 	 * Event type for receiving the message endpoint URI from the server. The server MUST
 	 * send this event when a client connects, providing the URI where the client should
 	 * send its messages via HTTP POST.
 	 */
-	private final static String ENDPOINT_EVENT_TYPE = "endpoint";
+	private static final String ENDPOINT_EVENT_TYPE = "endpoint";
 
 	/**
 	 * Default SSE endpoint path as specified by the MCP transport specification. This
 	 * endpoint is used to establish the SSE connection with the server.
 	 */
-	private final static String SSE_ENDPOINT = "/sse";
+	private static final String SSE_ENDPOINT = "/sse";
 
 	/**
 	 * Type reference for parsing SSE events containing string data.
 	 */
-	private final static ParameterizedTypeReference<ServerSentEvent<String>> SSE_TYPE = new ParameterizedTypeReference<>() {
+	private static final ParameterizedTypeReference<ServerSentEvent<String>> SSE_TYPE = new ParameterizedTypeReference<>() {
 	};
 
 	/**

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpAsyncClient.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpAsyncClient.java
@@ -62,7 +62,7 @@ import org.springframework.ai.mcp.util.Utils;
  */
 public class McpAsyncClient {
 
-	private final static Logger logger = LoggerFactory.getLogger(McpAsyncClient.class);
+	private static final Logger logger = LoggerFactory.getLogger(McpAsyncClient.class);
 
 	private static TypeReference<Void> VOID_TYPE_REFERENCE = new TypeReference<>() {
 	};
@@ -498,7 +498,7 @@ public class McpAsyncClient {
 			logger.error("Error handling tools list change notification", error);
 			return Mono.empty();
 		}).then(); // Convert to Mono<Void>
-	};
+	}
 
 	// --------------------------
 	// Resources
@@ -619,7 +619,7 @@ public class McpAsyncClient {
 			logger.error("Error handling resources list change notification", error);
 			return Mono.empty();
 		}).then();
-	};
+	}
 
 	// --------------------------
 	// Prompts
@@ -680,7 +680,7 @@ public class McpAsyncClient {
 				return Mono.empty();
 			}).then(); // Convert to Mono<Void>
 		}; // @formatter:on
-	};
+	}
 
 	// --------------------------
 	// Logging

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/transport/HttpClientSseClientTransport.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/transport/HttpClientSseClientTransport.java
@@ -70,16 +70,16 @@ import java.util.function.Function;
  */
 public class HttpClientSseClientTransport implements ClientMcpTransport {
 
-	private final static Logger logger = LoggerFactory.getLogger(HttpClientSseClientTransport.class);
+	private static final Logger logger = LoggerFactory.getLogger(HttpClientSseClientTransport.class);
 
 	/** SSE event type for JSON-RPC messages */
-	private final static String MESSAGE_EVENT_TYPE = "message";
+	private static final String MESSAGE_EVENT_TYPE = "message";
 
 	/** SSE event type for endpoint discovery */
-	private final static String ENDPOINT_EVENT_TYPE = "endpoint";
+	private static final String ENDPOINT_EVENT_TYPE = "endpoint";
 
 	/** Default SSE endpoint path */
-	private final static String SSE_ENDPOINT = "/sse";
+	private static final String SSE_ENDPOINT = "/sse";
 
 	/** Base URI for the MCP server */
 	private final String baseUri;
@@ -170,7 +170,7 @@ public class HttpClientSseClientTransport implements ClientMcpTransport {
 						handler.apply(Mono.just(message)).subscribe();
 					}
 					else {
-						logger.error("Received unrecognized SSE event type: " + event.type());
+						logger.error("Received unrecognized SSE event type: {}", event.type());
 					}
 				}
 				catch (IOException e) {

--- a/mcp/src/main/java/org/springframework/ai/mcp/server/McpAsyncServer.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/server/McpAsyncServer.java
@@ -54,7 +54,7 @@ import org.springframework.ai.mcp.util.Utils;
  */
 public class McpAsyncServer {
 
-	private final static Logger logger = LoggerFactory.getLogger(McpAsyncServer.class);
+	private static final Logger logger = LoggerFactory.getLogger(McpAsyncServer.class);
 
 	/**
 	 * The MCP session implementation that manages bidirectional JSON-RPC communication
@@ -279,7 +279,7 @@ public class McpAsyncServer {
 				return Mono.empty();
 			}).then();
 		};
-	};
+	}
 
 	// ---------------------------------------
 	// Tool Management
@@ -352,9 +352,7 @@ public class McpAsyncServer {
 	private DefaultMcpSession.RequestHandler toolsListRequestHandler() {
 		return params -> {
 
-			List<Tool> tools = this.tools.stream().map(toolRegistration -> {
-				return toolRegistration.tool();
-			}).toList();
+			List<Tool> tools = this.tools.stream().map(ToolRegistration::tool).toList();
 
 			return Mono.just(new McpSchema.ListToolsResult(tools, null));
 		};

--- a/mcp/src/main/java/org/springframework/ai/mcp/server/McpServer.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/server/McpServer.java
@@ -208,7 +208,7 @@ public interface McpServer {
 	 */
 	public static class Builder {
 
-		private final static McpSchema.Implementation DEFAULT_SERVER_INFO = new McpSchema.Implementation("mcp-server",
+		private static final McpSchema.Implementation DEFAULT_SERVER_INFO = new McpSchema.Implementation("mcp-server",
 				"1.0.0");
 
 		private final ServerMcpTransport transport;

--- a/mcp/src/main/java/org/springframework/ai/mcp/spec/McpSchema.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/spec/McpSchema.java
@@ -140,7 +140,7 @@ public final class McpSchema {
 
 	}
 
-	private final static TypeReference<HashMap<String, Object>> MAP_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<HashMap<String, Object>> MAP_TYPE_REF = new TypeReference<>() {
 	};
 
 	/**

--- a/mcp/src/test/java/org/springframework/ai/mcp/spec/DefaultMcpSessionTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/spec/DefaultMcpSessionTests.java
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 class DefaultMcpSessionTests {
 
-	private final static Logger logger = LoggerFactory.getLogger(DefaultMcpSessionTests.class);
+	private static final Logger logger = LoggerFactory.getLogger(DefaultMcpSessionTests.class);
 
 	private static final Duration TIMEOUT = Duration.ofSeconds(5);
 


### PR DESCRIPTION
This commit updates the WebFluxSseServerTransport, WebMvcSseServerTransport, and HttpServletSseServerTransport classes to accept the SSE endpoint path as a constructor argument.

This change provides more flexibility in configuring the SSE endpoint, allowing it to be customized instead of being hardcoded to "/sse". It also aligns the Java SDK's behavior with the Python SDK's SseServerTransport, which already supports this customization.

A default SSE endpoint of "/sse" is maintained for backward compatibility.

Also, addressed minor code quality issues identified by SonarLint and reordered modifiers for static final fields to conform with the Java Language Specification.