### PR TITLE
Refactor APIs for async and sync interactions

### DIFF
--- a/mcp-test/src/main/java/org/springframework/ai/mcp/client/BlaAbstractMcpSyncClientTests.java
+++ b/mcp-test/src/main/java/org/springframework/ai/mcp/client/BlaAbstractMcpSyncClientTests.java
@@ -72,10 +72,10 @@ public abstract class BlaAbstractMcpSyncClientTests {
 		this.mcpTransport = createMcpTransport();
 
 		assertThatCode(() -> {
-			mcpSyncClient = McpClient.using(mcpTransport)
+			mcpSyncClient = McpClient.sync(mcpTransport)
 				.requestTimeout(TIMEOUT)
 				.capabilities(ClientCapabilities.builder().roots(true).build())
-				.sync();
+				.build();
 			mcpSyncClient.initialize();
 		}).doesNotThrowAnyException();
 	}
@@ -90,10 +90,10 @@ public abstract class BlaAbstractMcpSyncClientTests {
 
 	@Test
 	void testConstructorWithInvalidArguments() {
-		assertThatThrownBy(() -> McpClient.using(null).sync()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> McpClient.sync(null).build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Transport must not be null");
 
-		assertThatThrownBy(() -> McpClient.using(mcpTransport).requestTimeout(null).sync())
+		assertThatThrownBy(() -> McpClient.sync(mcpTransport).requestTimeout(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Request timeout must not be null");
 	}
@@ -180,10 +180,10 @@ public abstract class BlaAbstractMcpSyncClientTests {
 	void testInitializeWithRootsListProviders() {
 		var transport = createMcpTransport();
 
-		var client = McpClient.using(transport)
+		var client = McpClient.sync(transport)
 			.requestTimeout(TIMEOUT)
 			.roots(new Root("file:///test/path", "test-root"))
-			.sync();
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize();
@@ -262,12 +262,12 @@ public abstract class BlaAbstractMcpSyncClientTests {
 		AtomicBoolean promptsNotificationReceived = new AtomicBoolean(false);
 
 		var transport = createMcpTransport();
-		var client = McpClient.using(transport)
+		var client = McpClient.sync(transport)
 			.requestTimeout(TIMEOUT)
 			.toolsChangeConsumer(tools -> toolsNotificationReceived.set(true))
 			.resourcesChangeConsumer(resources -> resourcesNotificationReceived.set(true))
 			.promptsChangeConsumer(prompts -> promptsNotificationReceived.set(true))
-			.sync();
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize();
@@ -295,10 +295,10 @@ public abstract class BlaAbstractMcpSyncClientTests {
 		AtomicBoolean logReceived = new AtomicBoolean(false);
 		var transport = createMcpTransport();
 
-		var client = McpClient.using(transport)
+		var client = McpClient.sync(transport)
 			.requestTimeout(TIMEOUT)
 			.loggingConsumer(notification -> logReceived.set(true))
-			.sync();
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize();

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpAsyncClient.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpAsyncClient.java
@@ -488,7 +488,7 @@ public class McpAsyncClient {
 		return this.mcpSession.sendNotification(McpSchema.METHOD_NOTIFICATION_ROOTS_LIST_CHANGED);
 	}
 
-	private RequestHandler rootsListRequestHandler() {
+	private RequestHandler<McpSchema.ListRootsResult> rootsListRequestHandler() {
 		return params -> {
 			McpSchema.PaginatedRequest request = transport.unmarshalFrom(params,
 					new TypeReference<McpSchema.PaginatedRequest>() {
@@ -516,10 +516,10 @@ public class McpAsyncClient {
 	// --------------------------
 	// Tools
 	// --------------------------
-	private static TypeReference<McpSchema.CallToolResult> CALL_TOOL_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<McpSchema.CallToolResult> CALL_TOOL_RESULT_TYPE_REF = new TypeReference<>() {
 	};
 
-	private static TypeReference<McpSchema.ListToolsResult> LIST_TOOLS_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<McpSchema.ListToolsResult> LIST_TOOLS_RESULT_TYPE_REF = new TypeReference<>() {
 	};
 
 	/**
@@ -572,6 +572,7 @@ public class McpAsyncClient {
 	 * list to all registered consumers 3. Handling any errors that occur during this
 	 * process
 	 */
+	@Deprecated
 	private NotificationHandler toolsChangeNotificationHandler(
 			List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers) {
 
@@ -602,6 +603,10 @@ public class McpAsyncClient {
 		// TODO: params are not used yet
 		return params -> listTools().flatMap(listToolsResult -> Flux.fromIterable(toolsChangeConsumers)
 			.flatMap(consumer -> consumer.apply(listToolsResult.tools()))
+			.onErrorResume(error -> {
+				logger.error("Error handling tools list change notification", error);
+				return Mono.empty();
+			})
 			.then());
 	}
 
@@ -609,13 +614,13 @@ public class McpAsyncClient {
 	// Resources
 	// --------------------------
 
-	private static TypeReference<McpSchema.ListResourcesResult> LIST_RESOURCES_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<McpSchema.ListResourcesResult> LIST_RESOURCES_RESULT_TYPE_REF = new TypeReference<>() {
 	};
 
-	private static TypeReference<McpSchema.ReadResourceResult> READ_RESOURCE_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<McpSchema.ReadResourceResult> READ_RESOURCE_RESULT_TYPE_REF = new TypeReference<>() {
 	};
 
-	private static TypeReference<McpSchema.ListResourceTemplatesResult> LIST_RESOURCE_TEMPLATES_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<McpSchema.ListResourceTemplatesResult> LIST_RESOURCE_TEMPLATES_RESULT_TYPE_REF = new TypeReference<>() {
 	};
 
 	/**
@@ -713,6 +718,7 @@ public class McpAsyncClient {
 				VOID_TYPE_REFERENCE);
 	}
 
+	@Deprecated
 	private NotificationHandler resourcesChangeNotificationHandler(
 			List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers) {
 
@@ -730,16 +736,20 @@ public class McpAsyncClient {
 			List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers) {
 		return params -> listResources().flatMap(listResourcesResult -> Flux.fromIterable(resourcesChangeConsumers)
 			.flatMap(consumer -> consumer.apply(listResourcesResult.resources()))
+			.onErrorResume(error -> {
+				logger.error("Error handling resources list change notification", error);
+				return Mono.empty();
+			})
 			.then());
 	}
 
 	// --------------------------
 	// Prompts
 	// --------------------------
-	private static TypeReference<McpSchema.ListPromptsResult> LIST_PROMPTS_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<McpSchema.ListPromptsResult> LIST_PROMPTS_RESULT_TYPE_REF = new TypeReference<>() {
 	};
 
-	private static TypeReference<McpSchema.GetPromptResult> GET_PROMPT_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<McpSchema.GetPromptResult> GET_PROMPT_RESULT_TYPE_REF = new TypeReference<>() {
 	};
 
 	/**
@@ -779,6 +789,7 @@ public class McpAsyncClient {
 		return this.mcpSession.sendNotification(McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED);
 	}
 
+	@Deprecated
 	private NotificationHandler promptsChangeNotificationHandler(
 			List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers) {
 
@@ -798,6 +809,10 @@ public class McpAsyncClient {
 			List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers) {
 		return params -> listPrompts().flatMap(listPromptsResult -> Flux.fromIterable(promptsChangeConsumers)
 			.flatMap(consumer -> consumer.apply(listPromptsResult.prompts()))
+			.onErrorResume(error -> {
+				logger.error("Error handling prompts list change notification", error);
+				return Mono.empty();
+			})
 			.then());
 	}
 

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpAsyncClient.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpAsyncClient.java
@@ -27,6 +27,7 @@ import java.util.function.Function;
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -109,12 +110,95 @@ public class McpAsyncClient {
 	 * request text or image-based interactions and optionally include context from MCP
 	 * servers in their prompts.
 	 */
-	private Function<CreateMessageRequest, CreateMessageResult> samplingHandler;
+	private Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler;
 
 	/**
 	 * Client transport implementation.
 	 */
 	private final McpTransport transport;
+
+	/**
+	 * Create a new McpAsyncClient with the given transport and session request-response
+	 * timeout.
+	 * @param transport the transport to use.
+	 * @param requestTimeout the session request-response timeout.
+	 * @param features the MCP Client supported features.
+	 */
+	McpAsyncClient(ClientMcpTransport transport, Duration requestTimeout, McpClientFeatures.Async features) {
+
+		Assert.notNull(transport, "Transport must not be null");
+		Assert.notNull(requestTimeout, "Request timeout must not be null");
+
+		this.clientInfo = features.clientInfo();
+		this.clientCapabilities = features.clientCapabilities();
+		this.transport = transport;
+		this.roots = new ConcurrentHashMap<>(features.roots());
+
+		// Request Handlers
+		Map<String, RequestHandler<?>> requestHandlers = new HashMap<>();
+
+		// Roots List Request Handler
+		if (this.clientCapabilities.roots() != null) {
+			requestHandlers.put(McpSchema.METHOD_ROOTS_LIST, rootsListRequestHandler());
+		}
+
+		// Sampling Handler
+		if (this.clientCapabilities.sampling() != null) {
+			if (features.samplingHandler() == null) {
+				throw new McpError("Sampling handler must not be null when client capabilities include sampling");
+			}
+			this.samplingHandler = features.samplingHandler();
+			requestHandlers.put(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, samplingCreateMessageHandler());
+		}
+
+		// Notification Handlers
+		Map<String, NotificationHandler> notificationHandlers = new HashMap<>();
+
+		// Tools Change Notification
+		List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumersFinal = new ArrayList<>();
+		toolsChangeConsumersFinal
+			.add((notification) -> Mono.fromRunnable(() -> logger.info("Tools changed: {}", notification)));
+
+		if (!Utils.isEmpty(features.toolsChangeConsumers())) {
+			toolsChangeConsumersFinal.addAll(features.toolsChangeConsumers());
+		}
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED,
+				asyncToolsChangeNotificationHandler(toolsChangeConsumersFinal));
+
+		// Resources Change Notification
+		List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumersFinal = new ArrayList<>();
+		resourcesChangeConsumersFinal
+			.add((notification) -> Mono.fromRunnable(() -> logger.info("Resources changed: {}", notification)));
+
+		if (!Utils.isEmpty(features.resourcesChangeConsumers())) {
+			resourcesChangeConsumersFinal.addAll(features.resourcesChangeConsumers());
+		}
+
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED,
+				asyncResourcesChangeNotificationHandler(resourcesChangeConsumersFinal));
+
+		// Prompts Change Notification
+		List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumersFinal = new ArrayList<>();
+		promptsChangeConsumersFinal
+			.add((notification) -> Mono.fromRunnable(() -> logger.info("Prompts changed: {}", notification)));
+		if (!Utils.isEmpty(features.promptsChangeConsumers())) {
+			promptsChangeConsumersFinal.addAll(features.promptsChangeConsumers());
+		}
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED,
+				asyncPromptsChangeNotificationHandler(promptsChangeConsumersFinal));
+
+		// Utility Logging Notification
+		List<Function<LoggingMessageNotification, Mono<Void>>> loggingConsumersFinal = new ArrayList<>();
+		loggingConsumersFinal.add((notification) -> Mono.fromRunnable(() -> logger.info("Logging: {}", notification)));
+		if (!Utils.isEmpty(features.loggingConsumers())) {
+			loggingConsumersFinal.addAll(features.loggingConsumers());
+		}
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_MESSAGE,
+				asyncLoggingNotificationHandler(loggingConsumersFinal));
+
+		this.mcpSession = new DefaultMcpSession(requestTimeout, transport, requestHandlers, notificationHandlers);
+
+	}
 
 	/**
 	 * Create a new McpAsyncClient with the given transport and session request-response
@@ -129,7 +213,9 @@ public class McpAsyncClient {
 	 * @param promptsChangeConsumers the prompts change consumers.
 	 * @param loggingConsumers the logging consumers.
 	 * @param samplingHandler the sampling handler.
+	 * @deprecated Use {@link McpClient#async(ClientMcpTransport)} to obtain an instance.
 	 */
+	@Deprecated
 	public McpAsyncClient(ClientMcpTransport transport, Duration requestTimeout, Implementation clientInfo,
 			ClientCapabilities clientCapabilities, Map<String, Root> roots,
 			List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
@@ -153,11 +239,11 @@ public class McpAsyncClient {
 		this.roots = roots != null ? new ConcurrentHashMap<>(roots) : new ConcurrentHashMap<>();
 
 		// Request Handlers
-		Map<String, RequestHandler> requestHanlers = new HashMap<>();
+		Map<String, RequestHandler<?>> requestHandlers = new HashMap<>();
 
 		// Roots List Request Handler
-		if (this.roots != null && this.clientCapabilities.roots() != null) {
-			requestHanlers.put(McpSchema.METHOD_ROOTS_LIST, rootsListRequestHandler());
+		if (this.clientCapabilities.roots() != null) {
+			requestHandlers.put(McpSchema.METHOD_ROOTS_LIST, rootsListRequestHandler());
 		}
 
 		// Sampling Handler
@@ -165,8 +251,9 @@ public class McpAsyncClient {
 			if (samplingHandler == null) {
 				throw new McpError("Sampling handler must not be null when client capabilities include sampling");
 			}
-			this.samplingHandler = samplingHandler;
-			requestHanlers.put(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, samplingCreateMessageHandler());
+			this.samplingHandler = r -> Mono.fromCallable(() -> samplingHandler.apply(r))
+				.subscribeOn(Schedulers.boundedElastic());
+			requestHandlers.put(McpSchema.METHOD_SAMPLING_CREATE_MESSAGE, samplingCreateMessageHandler());
 		}
 
 		// Notification Handlers
@@ -208,7 +295,7 @@ public class McpAsyncClient {
 		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_MESSAGE,
 				loggingNotificationHandler(loggingConsumersFinal));
 
-		this.mcpSession = new DefaultMcpSession(requestTimeout, transport, requestHanlers, notificationHandlers);
+		this.mcpSession = new DefaultMcpSession(requestTimeout, transport, requestHandlers, notificationHandlers);
 
 	}
 
@@ -416,15 +503,13 @@ public class McpAsyncClient {
 	// --------------------------
 	// Sampling
 	// --------------------------
-	private RequestHandler samplingCreateMessageHandler() {
+	private RequestHandler<CreateMessageResult> samplingCreateMessageHandler() {
 		return params -> {
 			McpSchema.CreateMessageRequest request = transport.unmarshalFrom(params,
 					new TypeReference<McpSchema.CreateMessageRequest>() {
 					});
 
-			CreateMessageResult response = this.samplingHandler.apply(request);
-
-			return Mono.just(response);
+			return this.samplingHandler.apply(request);
 		};
 	}
 
@@ -498,6 +583,26 @@ public class McpAsyncClient {
 			logger.error("Error handling tools list change notification", error);
 			return Mono.empty();
 		}).then(); // Convert to Mono<Void>
+	}
+
+	/**
+	 * Creates a notification handler for tools/list_changed notifications from the
+	 * server. When the server's available tools change, it sends a notification to inform
+	 * connected clients. This handler automatically fetches the updated tool list and
+	 * distributes it to all registered consumers.
+	 * @param toolsChangeConsumers List of consumers that will be notified when the tools
+	 * list changes. Each consumer receives the complete updated list of tools.
+	 * @return A NotificationHandler that processes tools/list_changed notifications by:
+	 * 1. Fetching the current list of tools from the server 2. Distributing the updated
+	 * list to all registered consumers 3. Handling any errors that occur during this
+	 * process
+	 */
+	private NotificationHandler asyncToolsChangeNotificationHandler(
+			List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers) {
+		// TODO: params are not used yet
+		return params -> listTools().flatMap(listToolsResult -> Flux.fromIterable(toolsChangeConsumers)
+			.flatMap(consumer -> consumer.apply(listToolsResult.tools()))
+			.then());
 	}
 
 	// --------------------------
@@ -621,6 +726,13 @@ public class McpAsyncClient {
 		}).then();
 	}
 
+	private NotificationHandler asyncResourcesChangeNotificationHandler(
+			List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers) {
+		return params -> listResources().flatMap(listResourcesResult -> Flux.fromIterable(resourcesChangeConsumers)
+			.flatMap(consumer -> consumer.apply(listResourcesResult.resources()))
+			.then());
+	}
+
 	// --------------------------
 	// Prompts
 	// --------------------------
@@ -682,6 +794,13 @@ public class McpAsyncClient {
 		}; // @formatter:on
 	}
 
+	private NotificationHandler asyncPromptsChangeNotificationHandler(
+			List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers) {
+		return params -> listPrompts().flatMap(listPromptsResult -> Flux.fromIterable(promptsChangeConsumers)
+			.flatMap(consumer -> consumer.apply(listPromptsResult.prompts()))
+			.then());
+	}
+
 	// --------------------------
 	// Logging
 	// --------------------------
@@ -708,6 +827,28 @@ public class McpAsyncClient {
 				}
 			}).subscribeOn(Schedulers.boundedElastic()).then();
 
+		};
+	}
+
+	/**
+	 * Create a notification handler for logging notifications from the server. This
+	 * handler automatically distributes logging messages to all registered consumers.
+	 * @param loggingConsumers List of consumers that will be notified when a logging
+	 * message is received. Each consumer receives the logging message notification.
+	 * @return A NotificationHandler that processes log notifications by distributing the
+	 * message to all registered consumers
+	 */
+	private NotificationHandler asyncLoggingNotificationHandler(
+			List<Function<LoggingMessageNotification, Mono<Void>>> loggingConsumers) {
+
+		return params -> {
+			McpSchema.LoggingMessageNotification loggingMessageNotification = transport.unmarshalFrom(params,
+					new TypeReference<McpSchema.LoggingMessageNotification>() {
+					});
+
+			return Flux.fromIterable(loggingConsumers)
+				.flatMap(consumer -> consumer.apply(loggingMessageNotification))
+				.then();
 		};
 	}
 

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpClient.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpClient.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.ai.mcp.spec.ClientMcpTransport;
 import org.springframework.ai.mcp.spec.McpSchema;
 import org.springframework.ai.mcp.spec.McpSchema.ClientCapabilities;
@@ -115,7 +117,11 @@ public interface McpClient {
 	 * and {@code SseClientTransport} for SSE-based communication.
 	 * @return A new builder instance for configuring the client
 	 * @throws IllegalArgumentException if transport is null
+	 * @deprecated Use {@link #sync(ClientMcpTransport)} or
+	 * {@link #async(ClientMcpTransport)} specification builder to configure the client
+	 * and build an instance.
 	 */
+	@Deprecated
 	public static Builder using(ClientMcpTransport transport) {
 		return new Builder(transport);
 	}
@@ -136,7 +142,12 @@ public interface McpClient {
 	 * <li>Change notification handlers for tools, resources, and prompts
 	 * <li>Custom message sampling logic
 	 * </ul>
+	 *
+	 * @deprecated Use {@link #sync(ClientMcpTransport)} or
+	 * {@link #async(ClientMcpTransport)} specification builder to instantiate an
+	 * instance.
 	 */
+	@Deprecated
 	public static class Builder {
 
 		private final ClientMcpTransport transport;
@@ -351,6 +362,433 @@ public interface McpClient {
 					resourcesChangeConsumers, promptsChangeConsumers, loggingConsumers, samplingHandler);
 		}
 
+	}
+
+	/**
+	 * Synchronous client specification.
+	 */
+	class SyncSpec {
+
+		private final ClientMcpTransport transport;
+
+		private Duration requestTimeout = Duration.ofSeconds(20); // Default timeout
+
+		private ClientCapabilities capabilities;
+
+		private Implementation clientInfo = new Implementation("Spring AI MCP Client", "0.3.1");
+
+		private Map<String, Root> roots = new HashMap<>();
+
+		private List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers = new ArrayList<>();
+
+		private List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers = new ArrayList<>();
+
+		private List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers = new ArrayList<>();
+
+		private List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers = new ArrayList<>();
+
+		private Function<CreateMessageRequest, CreateMessageResult> samplingHandler;
+
+		private SyncSpec(ClientMcpTransport transport) {
+			this.transport = transport;
+		}
+
+		/**
+		 * Sets the duration to wait for server responses before timing out requests. This
+		 * timeout applies to all requests made through the client, including tool calls,
+		 * resource access, and prompt operations.
+		 * @param requestTimeout The duration to wait before timing out requests. Must not
+		 * be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if requestTimeout is null
+		 */
+		public SyncSpec requestTimeout(Duration requestTimeout) {
+			Assert.notNull(requestTimeout, "Request timeout must not be null");
+			this.requestTimeout = requestTimeout;
+			return this;
+		}
+
+		/**
+		 * Sets the client capabilities that will be advertised to the server during
+		 * connection initialization. Capabilities define what features the client
+		 * supports, such as tool execution, resource access, and prompt handling.
+		 * @param capabilities The client capabilities configuration. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if capabilities is null
+		 */
+		public SyncSpec capabilities(ClientCapabilities capabilities) {
+			Assert.notNull(capabilities, "Capabilities must not be null");
+			this.capabilities = capabilities;
+			return this;
+		}
+
+		/**
+		 * Sets the client implementation information that will be shared with the server
+		 * during connection initialization. This helps with version compatibility and
+		 * debugging.
+		 * @param clientInfo The client implementation details including name and version.
+		 * Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if clientInfo is null
+		 */
+		public SyncSpec clientInfo(Implementation clientInfo) {
+			Assert.notNull(clientInfo, "Client info must not be null");
+			this.clientInfo = clientInfo;
+			return this;
+		}
+
+		/**
+		 * Sets the root URIs that this client can access. Roots define the base URIs for
+		 * resources that the client can request from the server. For example, a root
+		 * might be "file://workspace" for accessing workspace files.
+		 * @param roots A list of root definitions. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if roots is null
+		 */
+		public SyncSpec roots(List<Root> roots) {
+			Assert.notNull(roots, "Roots must not be null");
+			for (Root root : roots) {
+				this.roots.put(root.uri(), root);
+			}
+			return this;
+		}
+
+		/**
+		 * Sets the root URIs that this client can access, using a varargs parameter for
+		 * convenience. This is an alternative to {@link #roots(List)}.
+		 * @param roots An array of root definitions. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if roots is null
+		 * @see #roots(List)
+		 */
+		public SyncSpec roots(Root... roots) {
+			Assert.notNull(roots, "Roots must not be null");
+			for (Root root : roots) {
+				this.roots.put(root.uri(), root);
+			}
+			return this;
+		}
+
+		/**
+		 * Sets a custom sampling handler for processing message creation requests. The
+		 * sampling handler can modify or validate messages before they are sent to the
+		 * server, enabling custom processing logic.
+		 * @param samplingHandler A function that processes message requests and returns
+		 * results. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if samplingHandler is null
+		 */
+		public SyncSpec sampling(Function<CreateMessageRequest, CreateMessageResult> samplingHandler) {
+			Assert.notNull(samplingHandler, "Sampling handler must not be null");
+			this.samplingHandler = samplingHandler;
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when the available tools change. This allows the
+		 * client to react to changes in the server's tool capabilities, such as tools
+		 * being added or removed.
+		 * @param toolsChangeConsumer A consumer that receives the updated list of
+		 * available tools. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if toolsChangeConsumer is null
+		 */
+		public SyncSpec toolsChangeConsumer(Consumer<List<McpSchema.Tool>> toolsChangeConsumer) {
+			Assert.notNull(toolsChangeConsumer, "Tools change consumer must not be null");
+			this.toolsChangeConsumers.add(toolsChangeConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when the available resources change. This allows
+		 * the client to react to changes in the server's resource availability, such as
+		 * files being added or removed.
+		 * @param resourcesChangeConsumer A consumer that receives the updated list of
+		 * available resources. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if resourcesChangeConsumer is null
+		 */
+		public SyncSpec resourcesChangeConsumer(Consumer<List<McpSchema.Resource>> resourcesChangeConsumer) {
+			Assert.notNull(resourcesChangeConsumer, "Resources change consumer must not be null");
+			this.resourcesChangeConsumers.add(resourcesChangeConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when the available prompts change. This allows
+		 * the client to react to changes in the server's prompt templates, such as new
+		 * templates being added or existing ones being modified.
+		 * @param promptsChangeConsumer A consumer that receives the updated list of
+		 * available prompts. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if promptsChangeConsumer is null
+		 */
+		public SyncSpec promptsChangeConsumer(Consumer<List<McpSchema.Prompt>> promptsChangeConsumer) {
+			Assert.notNull(promptsChangeConsumer, "Prompts change consumer must not be null");
+			this.promptsChangeConsumers.add(promptsChangeConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when logging messages are received from the
+		 * server. This allows the client to react to log messages, such as warnings or
+		 * errors, that are sent by the server.
+		 * @param loggingConsumer A consumer that receives logging messages. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 */
+		public SyncSpec loggingConsumer(Consumer<McpSchema.LoggingMessageNotification> loggingConsumer) {
+			Assert.notNull(loggingConsumer, "Logging consumer must not be null");
+			this.loggingConsumers.add(loggingConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds multiple consumers to be notified when logging messages are received from
+		 * the server. This allows the client to react to log messages, such as warnings
+		 * or errors, that are sent by the server.
+		 * @param loggingConsumers A list of consumers that receive logging messages. Must
+		 * not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public SyncSpec loggingConsumers(List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers) {
+			Assert.notNull(loggingConsumers, "Logging consumers must not be null");
+			this.loggingConsumers.addAll(loggingConsumers);
+			return this;
+		}
+
+		/**
+		 * Create an instance of {@link McpSyncClient} with the provided configurations or
+		 * sensible defaults.
+		 * @return a new instance of {@link McpSyncClient}.
+		 */
+		public McpSyncClient build() {
+			McpClientFeatures.Sync syncFeatures = new McpClientFeatures.Sync(this.clientInfo, this.capabilities,
+					this.roots, this.toolsChangeConsumers, this.resourcesChangeConsumers, this.promptsChangeConsumers,
+					this.loggingConsumers, this.samplingHandler);
+
+			McpClientFeatures.Async asyncFeatures = McpClientFeatures.Async.fromSync(syncFeatures);
+
+			return new McpSyncClient(new McpAsyncClient(transport, this.requestTimeout, asyncFeatures));
+		}
+
+	}
+
+	/**
+	 * Asynchronous client specification.
+	 */
+	class AsyncSpec {
+
+		private final ClientMcpTransport transport;
+
+		private Duration requestTimeout = Duration.ofSeconds(20); // Default timeout
+
+		private ClientCapabilities capabilities;
+
+		private Implementation clientInfo = new Implementation("Spring AI MCP Client", "0.3.1");
+
+		private Map<String, Root> roots = new HashMap<>();
+
+		private List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers = new ArrayList<>();
+
+		private List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers = new ArrayList<>();
+
+		private List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers = new ArrayList<>();
+
+		private List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers = new ArrayList<>();
+
+		private Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler;
+
+		private AsyncSpec(ClientMcpTransport transport) {
+			this.transport = transport;
+		}
+
+		/**
+		 * Sets the duration to wait for server responses before timing out requests. This
+		 * timeout applies to all requests made through the client, including tool calls,
+		 * resource access, and prompt operations.
+		 * @param requestTimeout The duration to wait before timing out requests. Must not
+		 * be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if requestTimeout is null
+		 */
+		public AsyncSpec requestTimeout(Duration requestTimeout) {
+			Assert.notNull(requestTimeout, "Request timeout must not be null");
+			this.requestTimeout = requestTimeout;
+			return this;
+		}
+
+		/**
+		 * Sets the client capabilities that will be advertised to the server during
+		 * connection initialization. Capabilities define what features the client
+		 * supports, such as tool execution, resource access, and prompt handling.
+		 * @param capabilities The client capabilities configuration. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if capabilities is null
+		 */
+		public AsyncSpec capabilities(ClientCapabilities capabilities) {
+			Assert.notNull(capabilities, "Capabilities must not be null");
+			this.capabilities = capabilities;
+			return this;
+		}
+
+		/**
+		 * Sets the client implementation information that will be shared with the server
+		 * during connection initialization. This helps with version compatibility and
+		 * debugging.
+		 * @param clientInfo The client implementation details including name and version.
+		 * Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if clientInfo is null
+		 */
+		public AsyncSpec clientInfo(Implementation clientInfo) {
+			Assert.notNull(clientInfo, "Client info must not be null");
+			this.clientInfo = clientInfo;
+			return this;
+		}
+
+		/**
+		 * Sets the root URIs that this client can access. Roots define the base URIs for
+		 * resources that the client can request from the server. For example, a root
+		 * might be "file://workspace" for accessing workspace files.
+		 * @param roots A list of root definitions. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if roots is null
+		 */
+		public AsyncSpec roots(List<Root> roots) {
+			Assert.notNull(roots, "Roots must not be null");
+			for (Root root : roots) {
+				this.roots.put(root.uri(), root);
+			}
+			return this;
+		}
+
+		/**
+		 * Sets the root URIs that this client can access, using a varargs parameter for
+		 * convenience. This is an alternative to {@link #roots(List)}.
+		 * @param roots An array of root definitions. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if roots is null
+		 * @see #roots(List)
+		 */
+		public AsyncSpec roots(Root... roots) {
+			Assert.notNull(roots, "Roots must not be null");
+			for (Root root : roots) {
+				this.roots.put(root.uri(), root);
+			}
+			return this;
+		}
+
+		/**
+		 * Sets a custom sampling handler for processing message creation requests. The
+		 * sampling handler can modify or validate messages before they are sent to the
+		 * server, enabling custom processing logic.
+		 * @param samplingHandler A function that processes message requests and returns
+		 * results. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if samplingHandler is null
+		 */
+		public AsyncSpec sampling(Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler) {
+			Assert.notNull(samplingHandler, "Sampling handler must not be null");
+			this.samplingHandler = samplingHandler;
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when the available tools change. This allows the
+		 * client to react to changes in the server's tool capabilities, such as tools
+		 * being added or removed.
+		 * @param toolsChangeConsumer A consumer that receives the updated list of
+		 * available tools. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if toolsChangeConsumer is null
+		 */
+		public AsyncSpec toolsChangeConsumer(Function<List<McpSchema.Tool>, Mono<Void>> toolsChangeConsumer) {
+			Assert.notNull(toolsChangeConsumer, "Tools change consumer must not be null");
+			this.toolsChangeConsumers.add(toolsChangeConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when the available resources change. This allows
+		 * the client to react to changes in the server's resource availability, such as
+		 * files being added or removed.
+		 * @param resourcesChangeConsumer A consumer that receives the updated list of
+		 * available resources. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if resourcesChangeConsumer is null
+		 */
+		public AsyncSpec resourcesChangeConsumer(
+				Function<List<McpSchema.Resource>, Mono<Void>> resourcesChangeConsumer) {
+			Assert.notNull(resourcesChangeConsumer, "Resources change consumer must not be null");
+			this.resourcesChangeConsumers.add(resourcesChangeConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when the available prompts change. This allows
+		 * the client to react to changes in the server's prompt templates, such as new
+		 * templates being added or existing ones being modified.
+		 * @param promptsChangeConsumer A consumer that receives the updated list of
+		 * available prompts. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if promptsChangeConsumer is null
+		 */
+		public AsyncSpec promptsChangeConsumer(Function<List<McpSchema.Prompt>, Mono<Void>> promptsChangeConsumer) {
+			Assert.notNull(promptsChangeConsumer, "Prompts change consumer must not be null");
+			this.promptsChangeConsumers.add(promptsChangeConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds a consumer to be notified when logging messages are received from the
+		 * server. This allows the client to react to log messages, such as warnings or
+		 * errors, that are sent by the server.
+		 * @param loggingConsumer A consumer that receives logging messages. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 */
+		public AsyncSpec loggingConsumer(Function<McpSchema.LoggingMessageNotification, Mono<Void>> loggingConsumer) {
+			Assert.notNull(loggingConsumer, "Logging consumer must not be null");
+			this.loggingConsumers.add(loggingConsumer);
+			return this;
+		}
+
+		/**
+		 * Adds multiple consumers to be notified when logging messages are received from
+		 * the server. This allows the client to react to log messages, such as warnings
+		 * or errors, that are sent by the server.
+		 * @param loggingConsumers A list of consumers that receive logging messages. Must
+		 * not be null.
+		 * @return This builder instance for method chaining
+		 */
+		public AsyncSpec loggingConsumers(
+				List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers) {
+			Assert.notNull(loggingConsumers, "Logging consumers must not be null");
+			this.loggingConsumers.addAll(loggingConsumers);
+			return this;
+		}
+
+		/**
+		 * Create an instance of {@link McpAsyncClient} with the provided configurations
+		 * or sensible defaults.
+		 * @return a new instance of {@link McpAsyncClient}.
+		 */
+		public McpAsyncClient build() {
+			return new McpAsyncClient(this.transport, this.requestTimeout,
+					new McpClientFeatures.Async(this.clientInfo, this.capabilities, this.roots,
+							this.toolsChangeConsumers, this.resourcesChangeConsumers, this.promptsChangeConsumers,
+							this.loggingConsumers, this.samplingHandler));
+		}
+
+	}
+
+	static SyncSpec sync(ClientMcpTransport transport) {
+		return new SyncSpec(transport);
+	}
+
+	static AsyncSpec async(ClientMcpTransport transport) {
+		return new AsyncSpec(transport);
 	}
 
 }

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpClient.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpClient.java
@@ -61,14 +61,14 @@ import org.springframework.ai.mcp.util.Assert;
  *
  * <p>
  * Example of creating a basic client: <pre>{@code
- * McpClient.using(transport)
+ * McpClient.sync(transport) // or .async()
  *     .requestTimeout(Duration.ofSeconds(5))
- *     .sync(); // or .async()
+ *     .build();
  * }</pre>
  *
  * <p>
  * Example with advanced configuration: <pre>{@code
- * McpClient.using(transport)
+ * McpClient.sync(transport)
  *     .requestTimeout(Duration.ofSeconds(10))
  *     .capabilities(new ClientCapabilities(...))
  *     .clientInfo(new Implementation("My Client", "1.0.0"))
@@ -77,7 +77,7 @@ import org.springframework.ai.mcp.util.Assert;
  *     .resourcesChangeConsumer(resources -> System.out.println("Resources updated: " + resources))
  *     .promptsChangeConsumer(prompts -> System.out.println("Prompts updated: " + prompts))
  *     .loggingConsumer(message -> System.out.println("Log message: " + message))
- *     .async();
+ *     .build();
  * }</pre>
  *
  * <p>
@@ -107,6 +107,40 @@ import org.springframework.ai.mcp.util.Assert;
  * @see McpTransport
  */
 public interface McpClient {
+
+	/**
+	 * Start building a synchronous MCP client with the specified transport layer. The
+	 * synchronous MCP client provides blocking operations. Synchronous clients wait for
+	 * each operation to complete before returning, making them simpler to use but
+	 * potentially less performant for concurrent operations. The transport layer handles
+	 * the low-level communication between client and server using protocols like stdio or
+	 * Server-Sent Events (SSE).
+	 * @param transport The transport layer implementation for MCP communication. Common
+	 * implementations include {@code StdioClientTransport} for stdio-based communication
+	 * and {@code SseClientTransport} for SSE-based communication.
+	 * @return A new builder instance for configuring the client
+	 * @throws IllegalArgumentException if transport is null
+	 */
+	static SyncSpec sync(ClientMcpTransport transport) {
+		return new SyncSpec(transport);
+	}
+
+	/**
+	 * Start building an asynchronous MCP client with the specified transport layer. The
+	 * asynchronous MCP client provides non-blocking operations. Asynchronous clients
+	 * return reactive primitives (Mono/Flux) immediately, allowing for concurrent
+	 * operations and reactive programming patterns. The transport layer handles the
+	 * low-level communication between client and server using protocols like stdio or
+	 * Server-Sent Events (SSE).
+	 * @param transport The transport layer implementation for MCP communication. Common
+	 * implementations include {@code StdioClientTransport} for stdio-based communication
+	 * and {@code SseClientTransport} for SSE-based communication.
+	 * @return A new builder instance for configuring the client
+	 * @throws IllegalArgumentException if transport is null
+	 */
+	static AsyncSpec async(ClientMcpTransport transport) {
+		return new AsyncSpec(transport);
+	}
 
 	/**
 	 * Start building an MCP client with the specified transport layer. The transport
@@ -365,7 +399,20 @@ public interface McpClient {
 	}
 
 	/**
-	 * Synchronous client specification.
+	 * Synchronous client specification. This class follows the builder pattern to provide
+	 * a fluent API for setting up clients with custom configurations.
+	 *
+	 * <p>
+	 * The builder supports configuration of:
+	 * <ul>
+	 * <li>Transport layer for client-server communication
+	 * <li>Request timeouts for operation boundaries
+	 * <li>Client capabilities for feature negotiation
+	 * <li>Client implementation details for version tracking
+	 * <li>Root URIs for resource access
+	 * <li>Change notification handlers for tools, resources, and prompts
+	 * <li>Custom message sampling logic
+	 * </ul>
 	 */
 	class SyncSpec {
 
@@ -375,21 +422,22 @@ public interface McpClient {
 
 		private ClientCapabilities capabilities;
 
-		private Implementation clientInfo = new Implementation("Spring AI MCP Client", "0.3.1");
+		private Implementation clientInfo = new Implementation("Spring AI MCP Client", "1.0.0");
 
-		private Map<String, Root> roots = new HashMap<>();
+		private final Map<String, Root> roots = new HashMap<>();
 
-		private List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers = new ArrayList<>();
+		private final List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers = new ArrayList<>();
 
-		private List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers = new ArrayList<>();
+		private final List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers = new ArrayList<>();
 
-		private List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers = new ArrayList<>();
+		private final List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers = new ArrayList<>();
 
-		private List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers = new ArrayList<>();
+		private final List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers = new ArrayList<>();
 
 		private Function<CreateMessageRequest, CreateMessageResult> samplingHandler;
 
 		private SyncSpec(ClientMcpTransport transport) {
+			Assert.notNull(transport, "Transport must not be null");
 			this.transport = transport;
 		}
 
@@ -575,7 +623,20 @@ public interface McpClient {
 	}
 
 	/**
-	 * Asynchronous client specification.
+	 * Asynchronous client specification. This class follows the builder pattern to
+	 * provide a fluent API for setting up clients with custom configurations.
+	 *
+	 * <p>
+	 * The builder supports configuration of:
+	 * <ul>
+	 * <li>Transport layer for client-server communication
+	 * <li>Request timeouts for operation boundaries
+	 * <li>Client capabilities for feature negotiation
+	 * <li>Client implementation details for version tracking
+	 * <li>Root URIs for resource access
+	 * <li>Change notification handlers for tools, resources, and prompts
+	 * <li>Custom message sampling logic
+	 * </ul>
 	 */
 	class AsyncSpec {
 
@@ -587,19 +648,20 @@ public interface McpClient {
 
 		private Implementation clientInfo = new Implementation("Spring AI MCP Client", "0.3.1");
 
-		private Map<String, Root> roots = new HashMap<>();
+		private final Map<String, Root> roots = new HashMap<>();
 
-		private List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers = new ArrayList<>();
+		private final List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers = new ArrayList<>();
 
-		private List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers = new ArrayList<>();
+		private final List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers = new ArrayList<>();
 
-		private List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers = new ArrayList<>();
+		private final List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers = new ArrayList<>();
 
-		private List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers = new ArrayList<>();
+		private final List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers = new ArrayList<>();
 
 		private Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler;
 
 		private AsyncSpec(ClientMcpTransport transport) {
+			Assert.notNull(transport, "Transport must not be null");
 			this.transport = transport;
 		}
 
@@ -781,14 +843,6 @@ public interface McpClient {
 							this.loggingConsumers, this.samplingHandler));
 		}
 
-	}
-
-	static SyncSpec sync(ClientMcpTransport transport) {
-		return new SyncSpec(transport);
-	}
-
-	static AsyncSpec async(ClientMcpTransport transport) {
-		return new AsyncSpec(transport);
 	}
 
 }

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpClientFeatures.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpClientFeatures.java
@@ -16,7 +16,9 @@ import org.springframework.ai.mcp.util.Assert;
 import org.springframework.ai.mcp.util.Utils;
 
 /**
- * Internal representation of features that the client exposes.
+ * Representation of features that the client exposes.
+ *
+ * @author Dariusz Jędrzejczyk
  */
 class McpClientFeatures {
 
@@ -68,10 +70,10 @@ class McpClientFeatures {
 							samplingHandler != null ? new McpSchema.ClientCapabilities.Sampling() : null);
 			this.roots = roots != null ? new ConcurrentHashMap<>(roots) : new ConcurrentHashMap<>();
 
-			this.toolsChangeConsumers = toolsChangeConsumers;
-			this.resourcesChangeConsumers = resourcesChangeConsumers;
-			this.promptsChangeConsumers = promptsChangeConsumers;
-			this.loggingConsumers = loggingConsumers;
+			this.toolsChangeConsumers = toolsChangeConsumers != null ? toolsChangeConsumers : List.of();
+			this.resourcesChangeConsumers = resourcesChangeConsumers != null ? resourcesChangeConsumers : List.of();
+			this.promptsChangeConsumers = promptsChangeConsumers != null ? promptsChangeConsumers : List.of();
+			this.loggingConsumers = loggingConsumers != null ? loggingConsumers : List.of();
 			this.samplingHandler = samplingHandler;
 		}
 
@@ -165,10 +167,10 @@ class McpClientFeatures {
 							samplingHandler != null ? new McpSchema.ClientCapabilities.Sampling() : null);
 			this.roots = roots != null ? new HashMap<>(roots) : new HashMap<>();
 
-			this.toolsChangeConsumers = toolsChangeConsumers;
-			this.resourcesChangeConsumers = resourcesChangeConsumers;
-			this.promptsChangeConsumers = promptsChangeConsumers;
-			this.loggingConsumers = loggingConsumers;
+			this.toolsChangeConsumers = toolsChangeConsumers != null ? toolsChangeConsumers : List.of();
+			this.resourcesChangeConsumers = resourcesChangeConsumers != null ? resourcesChangeConsumers : List.of();
+			this.promptsChangeConsumers = promptsChangeConsumers != null ? promptsChangeConsumers : List.of();
+			this.loggingConsumers = loggingConsumers != null ? loggingConsumers : List.of();
 			this.samplingHandler = samplingHandler;
 		}
 	}

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpClientFeatures.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpClientFeatures.java
@@ -1,0 +1,176 @@
+package org.springframework.ai.mcp.client;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.mcp.spec.McpSchema;
+import org.springframework.ai.mcp.util.Assert;
+import org.springframework.ai.mcp.util.Utils;
+
+/**
+ * Internal representation of features that the client exposes.
+ */
+class McpClientFeatures {
+
+	/**
+	 * Asynchronous client features specification providing the capabilities and request
+	 * and notification handlers.
+	 *
+	 * @param clientInfo the client implementation information.
+	 * @param clientCapabilities the client capabilities.
+	 * @param roots the roots.
+	 * @param toolsChangeConsumers the tools change consumers.
+	 * @param resourcesChangeConsumers the resources change consumers.
+	 * @param promptsChangeConsumers the prompts change consumers.
+	 * @param loggingConsumers the logging consumers.
+	 * @param samplingHandler the sampling handler.
+	 */
+	record Async(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
+			Map<String, McpSchema.Root> roots, List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
+			List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers,
+			List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers,
+			List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers,
+			Function<McpSchema.CreateMessageRequest, Mono<McpSchema.CreateMessageResult>> samplingHandler) {
+
+		/**
+		 * Create an instance and validate the arguments.
+		 * @param clientInfo the client implementation information.
+		 * @param clientCapabilities the client capabilities.
+		 * @param roots the roots.
+		 * @param toolsChangeConsumers the tools change consumers.
+		 * @param resourcesChangeConsumers the resources change consumers.
+		 * @param promptsChangeConsumers the prompts change consumers.
+		 * @param loggingConsumers the logging consumers.
+		 * @param samplingHandler the sampling handler.
+		 */
+		public Async(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
+				Map<String, McpSchema.Root> roots,
+				List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers,
+				List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers,
+				List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers,
+				List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers,
+				Function<McpSchema.CreateMessageRequest, Mono<McpSchema.CreateMessageResult>> samplingHandler) {
+
+			Assert.notNull(clientInfo, "Client info must not be null");
+
+			this.clientInfo = clientInfo;
+			this.clientCapabilities = (clientCapabilities != null) ? clientCapabilities
+					: new McpSchema.ClientCapabilities(null,
+							!Utils.isEmpty(roots) ? new McpSchema.ClientCapabilities.RootCapabilities(false) : null,
+							samplingHandler != null ? new McpSchema.ClientCapabilities.Sampling() : null);
+			this.roots = roots != null ? new ConcurrentHashMap<>(roots) : new ConcurrentHashMap<>();
+
+			this.toolsChangeConsumers = toolsChangeConsumers;
+			this.resourcesChangeConsumers = resourcesChangeConsumers;
+			this.promptsChangeConsumers = promptsChangeConsumers;
+			this.loggingConsumers = loggingConsumers;
+			this.samplingHandler = samplingHandler;
+		}
+
+		/**
+		 * Convert a synchronous specification into an asynchronous one and provide
+		 * blocking code offloading to prevent accidental blocking of the non-blocking
+		 * transport.
+		 * @param syncSpec a potentially blocking, synchronous specification.
+		 * @return a specification which is protected from blocking calls specified by the
+		 * user.
+		 */
+		public static Async fromSync(Sync syncSpec) {
+			List<Function<List<McpSchema.Tool>, Mono<Void>>> toolsChangeConsumers = new ArrayList<>();
+			for (Consumer<List<McpSchema.Tool>> consumer : syncSpec.toolsChangeConsumers()) {
+				toolsChangeConsumers.add(t -> Mono.<Void>fromRunnable(() -> consumer.accept(t))
+					.subscribeOn(Schedulers.boundedElastic()));
+			}
+
+			List<Function<List<McpSchema.Resource>, Mono<Void>>> resourcesChangeConsumers = new ArrayList<>();
+			for (Consumer<List<McpSchema.Resource>> consumer : syncSpec.resourcesChangeConsumers()) {
+				resourcesChangeConsumers.add(r -> Mono.<Void>fromRunnable(() -> consumer.accept(r))
+					.subscribeOn(Schedulers.boundedElastic()));
+			}
+
+			List<Function<List<McpSchema.Prompt>, Mono<Void>>> promptsChangeConsumers = new ArrayList<>();
+
+			for (Consumer<List<McpSchema.Prompt>> consumer : syncSpec.promptsChangeConsumers()) {
+				promptsChangeConsumers.add(p -> Mono.<Void>fromRunnable(() -> consumer.accept(p))
+					.subscribeOn(Schedulers.boundedElastic()));
+			}
+
+			List<Function<McpSchema.LoggingMessageNotification, Mono<Void>>> loggingConsumers = new ArrayList<>();
+			for (Consumer<McpSchema.LoggingMessageNotification> consumer : syncSpec.loggingConsumers()) {
+				loggingConsumers.add(l -> Mono.<Void>fromRunnable(() -> consumer.accept(l))
+					.subscribeOn(Schedulers.boundedElastic()));
+			}
+
+			Function<McpSchema.CreateMessageRequest, Mono<McpSchema.CreateMessageResult>> samplingHandler = r -> Mono
+				.fromCallable(() -> syncSpec.samplingHandler().apply(r))
+				.subscribeOn(Schedulers.boundedElastic());
+			return new Async(syncSpec.clientInfo(), syncSpec.clientCapabilities(), syncSpec.roots(),
+					toolsChangeConsumers, resourcesChangeConsumers, promptsChangeConsumers, loggingConsumers,
+					samplingHandler);
+		}
+	}
+
+	/**
+	 * Synchronous client features specification providing the capabilities and request
+	 * and notification handlers.
+	 *
+	 * @param clientInfo the client implementation information.
+	 * @param clientCapabilities the client capabilities.
+	 * @param roots the roots.
+	 * @param toolsChangeConsumers the tools change consumers.
+	 * @param resourcesChangeConsumers the resources change consumers.
+	 * @param promptsChangeConsumers the prompts change consumers.
+	 * @param loggingConsumers the logging consumers.
+	 * @param samplingHandler the sampling handler.
+	 */
+	public record Sync(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
+			Map<String, McpSchema.Root> roots, List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
+			List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers,
+			List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers,
+			List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers,
+			Function<McpSchema.CreateMessageRequest, McpSchema.CreateMessageResult> samplingHandler) {
+
+		/**
+		 * Create an instance and validate the arguments.
+		 * @param clientInfo the client implementation information.
+		 * @param clientCapabilities the client capabilities.
+		 * @param roots the roots.
+		 * @param toolsChangeConsumers the tools change consumers.
+		 * @param resourcesChangeConsumers the resources change consumers.
+		 * @param promptsChangeConsumers the prompts change consumers.
+		 * @param loggingConsumers the logging consumers.
+		 * @param samplingHandler the sampling handler.
+		 */
+		public Sync(McpSchema.Implementation clientInfo, McpSchema.ClientCapabilities clientCapabilities,
+				Map<String, McpSchema.Root> roots, List<Consumer<List<McpSchema.Tool>>> toolsChangeConsumers,
+				List<Consumer<List<McpSchema.Resource>>> resourcesChangeConsumers,
+				List<Consumer<List<McpSchema.Prompt>>> promptsChangeConsumers,
+				List<Consumer<McpSchema.LoggingMessageNotification>> loggingConsumers,
+				Function<McpSchema.CreateMessageRequest, McpSchema.CreateMessageResult> samplingHandler) {
+
+			Assert.notNull(clientInfo, "Client info must not be null");
+
+			this.clientInfo = clientInfo;
+			this.clientCapabilities = (clientCapabilities != null) ? clientCapabilities
+					: new McpSchema.ClientCapabilities(null,
+							!Utils.isEmpty(roots) ? new McpSchema.ClientCapabilities.RootCapabilities(false) : null,
+							samplingHandler != null ? new McpSchema.ClientCapabilities.Sampling() : null);
+			this.roots = roots != null ? new HashMap<>(roots) : new HashMap<>();
+
+			this.toolsChangeConsumers = toolsChangeConsumers;
+			this.resourcesChangeConsumers = resourcesChangeConsumers;
+			this.promptsChangeConsumers = promptsChangeConsumers;
+			this.loggingConsumers = loggingConsumers;
+			this.samplingHandler = samplingHandler;
+		}
+	}
+
+}

--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpSyncClient.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpSyncClient.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.ai.mcp.spec.ClientMcpTransport;
 import org.springframework.ai.mcp.spec.McpSchema;
 import org.springframework.ai.mcp.spec.McpSchema.ClientCapabilities;
 import org.springframework.ai.mcp.spec.McpSchema.GetPromptRequest;
@@ -45,6 +46,14 @@ public class McpSyncClient implements AutoCloseable {
 
 	private final McpAsyncClient delegate;
 
+	/**
+	 * Create a new McpSyncClient with the given delegate.
+	 * @param delegate the asynchronous kernel on top of which this synchronous client
+	 * provides a blocking API.
+	 * @deprecated Use {@link McpClient#sync(ClientMcpTransport)} to obtain an instance.
+	 */
+	@Deprecated
+	// TODO make the constructor package private post-deprecation
 	public McpSyncClient(McpAsyncClient delegate) {
 		Assert.notNull(delegate, "The delegate can not be null");
 		this.delegate = delegate;

--- a/mcp/src/main/java/org/springframework/ai/mcp/server/McpAsyncServer.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/server/McpAsyncServer.java
@@ -24,10 +24,12 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
 
@@ -75,15 +77,83 @@ public class McpAsyncServer {
 	/**
 	 * Thread-safe list of tool handlers that can be modified at runtime.
 	 */
-	private final CopyOnWriteArrayList<ToolRegistration> tools;
+	private final CopyOnWriteArrayList<McpServerFeatures.AsyncToolRegistration> tools = new CopyOnWriteArrayList<>();
 
-	private final CopyOnWriteArrayList<McpSchema.ResourceTemplate> resourceTemplates;
+	private final CopyOnWriteArrayList<McpSchema.ResourceTemplate> resourceTemplates = new CopyOnWriteArrayList<>();
 
-	private final ConcurrentHashMap<String, ResourceRegistration> resources;
+	private final ConcurrentHashMap<String, McpServerFeatures.AsyncResourceRegistration> resources = new ConcurrentHashMap<>();
 
-	private final ConcurrentHashMap<String, PromptRegistration> prompts;
+	private final ConcurrentHashMap<String, McpServerFeatures.AsyncPromptRegistration> prompts = new ConcurrentHashMap<>();
 
 	private LoggingLevel minLoggingLevel = LoggingLevel.DEBUG;
+
+	/**
+	 * Create a new McpAsyncServer with the given transport and capabilities.
+	 * @param mcpTransport The transport layer implementation for MCP communication.
+	 * @param features The MCP server supported features.
+	 */
+	McpAsyncServer(ServerMcpTransport mcpTransport, McpServerFeatures.Async features) {
+		this.serverInfo = features.serverInfo();
+		this.serverCapabilities = features.serverCapabilities();
+		this.tools.addAll(features.tools());
+		this.resources.putAll(features.resources());
+		this.resourceTemplates.addAll(features.resourceTemplates());
+		this.prompts.putAll(features.prompts());
+
+		Map<String, DefaultMcpSession.RequestHandler<?>> requestHandlers = new HashMap<>();
+
+		// Initialize request handlers for standard MCP methods
+		requestHandlers.put(McpSchema.METHOD_INITIALIZE, initializeRequestHandler());
+
+		// Ping MUST respond with an empty data, but not NULL response.
+		requestHandlers.put(McpSchema.METHOD_PING, (params) -> Mono.just(""));
+
+		// Add tools API handlers if the tool capability is enabled
+		if (this.serverCapabilities.tools() != null) {
+			requestHandlers.put(McpSchema.METHOD_TOOLS_LIST, toolsListRequestHandler());
+			requestHandlers.put(McpSchema.METHOD_TOOLS_CALL, toolsCallRequestHandler());
+		}
+
+		// Add resources API handlers if provided
+		if (!Utils.isEmpty(this.resources)) {
+			requestHandlers.put(McpSchema.METHOD_RESOURCES_LIST, resourcesListRequestHandler());
+			requestHandlers.put(McpSchema.METHOD_RESOURCES_READ, resourcesReadRequestHandler());
+		}
+
+		// Add resource templates API handlers if provided.
+		if (!Utils.isEmpty(this.resourceTemplates)) {
+			requestHandlers.put(McpSchema.METHOD_RESOURCES_TEMPLATES_LIST, resourceTemplateListRequestHandler());
+		}
+
+		// Add prompts API handlers if provider exists
+		if (!Utils.isEmpty(this.prompts)) {
+			requestHandlers.put(McpSchema.METHOD_PROMPT_LIST, promptsListRequestHandler());
+			requestHandlers.put(McpSchema.METHOD_PROMPT_GET, promptsGetRequestHandler());
+		}
+
+		// Add logging API handlers if the logging capability is enabled
+		if (this.serverCapabilities.logging() != null) {
+			requestHandlers.put(McpSchema.METHOD_LOGGING_SET_LEVEL, setLoggerRequestHandler());
+		}
+
+		Map<String, NotificationHandler> notificationHandlers = new HashMap<>();
+
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_INITIALIZED, (params) -> Mono.empty());
+
+		List<Function<List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers = features.rootsChangeConsumers();
+
+		if (Utils.isEmpty(rootsChangeConsumers)) {
+			rootsChangeConsumers = List.of((roots) -> Mono.fromRunnable(() -> logger
+				.warn("Roots list changed notification, but no consumers provided. Roots list changed: {}", roots)));
+		}
+
+		notificationHandlers.put(McpSchema.METHOD_NOTIFICATION_ROOTS_LIST_CHANGED,
+				asyncRootsListChangedNotificationHandler(rootsChangeConsumers));
+
+		this.transport = mcpTransport;
+		this.mcpSession = new DefaultMcpSession(Duration.ofSeconds(10), mcpTransport, requestHandlers,
+				notificationHandlers);
+	}
 
 	/**
 	 * Create a new McpAsyncServer with the given transport and capabilities.
@@ -96,18 +166,28 @@ public class McpAsyncServer {
 	 * @param prompts The map of prompt registrations
 	 * @param rootsChangeConsumers The list of consumers that will be notified when the
 	 * roots list changes
+	 * @deprecated Use {@link McpServer#sync(ServerMcpTransport)} or
+	 * {@link McpServer#async(ServerMcpTransport)} to create a new server instance.
 	 */
+	@Deprecated
 	public McpAsyncServer(ServerMcpTransport mcpTransport, McpSchema.Implementation serverInfo,
 			McpSchema.ServerCapabilities serverCapabilities, List<ToolRegistration> tools,
 			Map<String, ResourceRegistration> resources, List<McpSchema.ResourceTemplate> resourceTemplates,
 			Map<String, PromptRegistration> prompts, List<Consumer<List<McpSchema.Root>>> rootsChangeConsumers) {
 
 		this.serverInfo = serverInfo;
-		this.tools = new CopyOnWriteArrayList<>(tools != null ? tools : List.of());
-		this.resources = !Utils.isEmpty(resources) ? new ConcurrentHashMap<>(resources) : new ConcurrentHashMap<>();
-		this.resourceTemplates = !Utils.isEmpty(resourceTemplates) ? new CopyOnWriteArrayList<>(resourceTemplates)
-				: new CopyOnWriteArrayList<>();
-		this.prompts = !Utils.isEmpty(prompts) ? new ConcurrentHashMap<>(prompts) : new ConcurrentHashMap<>();
+		if (!Utils.isEmpty(tools)) {
+			this.tools.addAll(McpServer.mapDeprecatedTools(tools));
+		}
+		if (!Utils.isEmpty(resources)) {
+			this.resources.putAll(McpServer.mapDeprecatedResources(resources));
+		}
+		if (!Utils.isEmpty(resourceTemplates)) {
+			this.resourceTemplates.addAll(resourceTemplates);
+		}
+		if (!Utils.isEmpty(prompts)) {
+			this.prompts.putAll(McpServer.mapDeprecatedPrompts(prompts));
+		}
 
 		this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities : new McpSchema.ServerCapabilities(
 				null, // experimental
@@ -118,13 +198,13 @@ public class McpAsyncServer {
 						: null,
 				!Utils.isEmpty(this.tools) ? new McpSchema.ServerCapabilities.ToolCapabilities(false) : null);
 
-		Map<String, DefaultMcpSession.RequestHandler> requestHandlers = new HashMap<>();
+		Map<String, DefaultMcpSession.RequestHandler<?>> requestHandlers = new HashMap<>();
 
 		// Initialize request handlers for standard MCP methods
 		requestHandlers.put(McpSchema.METHOD_INITIALIZE, initializeRequestHandler());
 
 		// Ping MUST respond with an empty data, but not NULL response.
-		requestHandlers.put(McpSchema.METHOD_PING, (params) -> Mono.<Object>just(""));
+		requestHandlers.put(McpSchema.METHOD_PING, (params) -> Mono.just(""));
 
 		// Add tools API handlers if the tool capability is enabled
 		if (this.serverCapabilities.tools() != null) {
@@ -173,7 +253,7 @@ public class McpAsyncServer {
 	// ---------------------------------------
 	// Lifecycle Management
 	// ---------------------------------------
-	private DefaultMcpSession.RequestHandler initializeRequestHandler() {
+	private DefaultMcpSession.RequestHandler<McpSchema.InitializeResult> initializeRequestHandler() {
 		return params -> {
 			McpSchema.InitializeRequest initializeRequest = transport.unmarshalFrom(params,
 					new TypeReference<McpSchema.InitializeRequest>() {
@@ -187,14 +267,13 @@ public class McpAsyncServer {
 					initializeRequest.clientInfo());
 
 			if (!McpSchema.LATEST_PROTOCOL_VERSION.equals(initializeRequest.protocolVersion())) {
-				return Mono
-					.<Object>error(new McpError(
-							"Unsupported protocol version from client: " + initializeRequest.protocolVersion()))
+				return Mono.<McpSchema.InitializeResult>error(new McpError(
+						"Unsupported protocol version from client: " + initializeRequest.protocolVersion()))
 					.publishOn(Schedulers.boundedElastic());
 			}
 
 			return Mono
-				.<Object>just(new McpSchema.InitializeResult(McpSchema.LATEST_PROTOCOL_VERSION, this.serverCapabilities,
+				.just(new McpSchema.InitializeResult(McpSchema.LATEST_PROTOCOL_VERSION, this.serverCapabilities,
 						this.serverInfo, null))
 				.publishOn(Schedulers.boundedElastic());
 		};
@@ -268,6 +347,7 @@ public class McpAsyncServer {
 				LIST_ROOTS_RESULT_TYPE_REF);
 	}
 
+	@Deprecated
 	private NotificationHandler rootsListChnagedNotificationHandler(
 			List<Consumer<List<McpSchema.Root>>> rootsChangeConsumers) {
 
@@ -281,6 +361,13 @@ public class McpAsyncServer {
 		};
 	}
 
+	private NotificationHandler asyncRootsListChangedNotificationHandler(
+			List<Function<List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers) {
+		return params -> listRoots().flatMap(listRootsResult -> Flux.fromIterable(rootsChangeConsumers)
+			.flatMap(consumer -> consumer.apply(listRootsResult.roots()))
+			.then());
+	}
+
 	// ---------------------------------------
 	// Tool Management
 	// ---------------------------------------
@@ -290,6 +377,44 @@ public class McpAsyncServer {
 	 * @param toolRegistration The tool registration to add
 	 * @return Mono that completes when clients have been notified of the change
 	 */
+	public Mono<Void> addTool(McpServerFeatures.AsyncToolRegistration toolRegistration) {
+		if (toolRegistration == null) {
+			return Mono.error(new McpError("Tool registration must not be null"));
+		}
+		if (toolRegistration.tool() == null) {
+			return Mono.error(new McpError("Tool must not be null"));
+		}
+		if (toolRegistration.call() == null) {
+			return Mono.error(new McpError("Tool call handler must not be null"));
+		}
+		if (this.serverCapabilities.tools() == null) {
+			return Mono.error(new McpError("Server must be configured with tool capabilities"));
+		}
+
+		return Mono.defer(() -> {
+			// Check for duplicate tool names
+			if (this.tools.stream().anyMatch(th -> th.tool().name().equals(toolRegistration.tool().name()))) {
+				return Mono
+					.error(new McpError("Tool with name '" + toolRegistration.tool().name() + "' already exists"));
+			}
+
+			this.tools.add(toolRegistration);
+			logger.info("Added tool handler: {}", toolRegistration.tool().name());
+
+			if (this.serverCapabilities.tools().listChanged()) {
+				return notifyToolsListChanged();
+			}
+			return Mono.empty();
+		});
+	}
+
+	/**
+	 * Add a new tool registration at runtime.
+	 * @param toolRegistration The tool registration to add
+	 * @return Mono that completes when clients have been notified of the change
+	 * @deprecated Use {@link #addTool(McpServerFeatures.AsyncToolRegistration)}.
+	 */
+	@Deprecated
 	public Mono<Void> addTool(ToolRegistration toolRegistration) {
 		if (toolRegistration == null) {
 			return Mono.error(new McpError("Tool registration must not be null"));
@@ -309,7 +434,7 @@ public class McpAsyncServer {
 			return Mono.error(new McpError("Tool with name '" + toolRegistration.tool().name() + "' already exists"));
 		}
 
-		this.tools.add(toolRegistration);
+		this.tools.add(McpServer.mapDeprecatedTool(toolRegistration));
 		logger.info("Added tool handler: {}", toolRegistration.tool().name());
 		if (this.serverCapabilities.tools().listChanged()) {
 			return notifyToolsListChanged();
@@ -330,15 +455,17 @@ public class McpAsyncServer {
 			return Mono.error(new McpError("Server must be configured with tool capabilities"));
 		}
 
-		boolean removed = this.tools.removeIf(toolRegistration -> toolRegistration.tool().name().equals(toolName));
-		if (removed) {
-			logger.info("Removed tool handler: {}", toolName);
-			if (this.serverCapabilities.tools().listChanged()) {
-				return notifyToolsListChanged();
+		return Mono.defer(() -> {
+			boolean removed = this.tools.removeIf(toolRegistration -> toolRegistration.tool().name().equals(toolName));
+			if (removed) {
+				logger.info("Removed tool handler: {}", toolName);
+				if (this.serverCapabilities.tools().listChanged()) {
+					return notifyToolsListChanged();
+				}
+				return Mono.empty();
 			}
-			return Mono.empty();
-		}
-		return Mono.error(new McpError("Tool with name '" + toolName + "' not found"));
+			return Mono.error(new McpError("Tool with name '" + toolName + "' not found"));
+		});
 	}
 
 	/**
@@ -349,32 +476,30 @@ public class McpAsyncServer {
 		return this.mcpSession.sendNotification(McpSchema.METHOD_NOTIFICATION_TOOLS_LIST_CHANGED, null);
 	}
 
-	private DefaultMcpSession.RequestHandler toolsListRequestHandler() {
+	private DefaultMcpSession.RequestHandler<McpSchema.ListToolsResult> toolsListRequestHandler() {
 		return params -> {
-
-			List<Tool> tools = this.tools.stream().map(ToolRegistration::tool).toList();
+			List<Tool> tools = this.tools.stream().map(McpServerFeatures.AsyncToolRegistration::tool).toList();
 
 			return Mono.just(new McpSchema.ListToolsResult(tools, null));
 		};
 	}
 
-	private DefaultMcpSession.RequestHandler toolsCallRequestHandler() {
+	private DefaultMcpSession.RequestHandler<CallToolResult> toolsCallRequestHandler() {
 		return params -> {
 			McpSchema.CallToolRequest callToolRequest = transport.unmarshalFrom(params,
 					new TypeReference<McpSchema.CallToolRequest>() {
 					});
 
-			Optional<ToolRegistration> toolRegistration = this.tools.stream()
+			Optional<McpServerFeatures.AsyncToolRegistration> toolRegistration = this.tools.stream()
 				.filter(tr -> callToolRequest.name().equals(tr.tool().name()))
 				.findAny();
 
 			if (toolRegistration.isEmpty()) {
-				return Mono.<Object>error(new McpError("Tool not found: " + callToolRequest.name()));
+				return Mono.error(new McpError("Tool not found: " + callToolRequest.name()));
 			}
 
-			return Mono.fromCallable(() -> toolRegistration.get().call().apply(callToolRequest.arguments()))
-				.map(result -> (Object) result)
-				.subscribeOn(Schedulers.boundedElastic());
+			return toolRegistration.map(tool -> tool.call().apply(callToolRequest.arguments()))
+				.orElse(Mono.error(new McpError("Tool not found: " + callToolRequest.name())));
 		};
 	}
 
@@ -387,6 +512,35 @@ public class McpAsyncServer {
 	 * @param resourceHandler The resource handler to add
 	 * @return Mono that completes when clients have been notified of the change
 	 */
+	public Mono<Void> addResource(McpServerFeatures.AsyncResourceRegistration resourceHandler) {
+		if (resourceHandler == null || resourceHandler.resource() == null) {
+			return Mono.error(new McpError("Resource must not be null"));
+		}
+
+		if (this.serverCapabilities.resources() == null) {
+			return Mono.error(new McpError("Server must be configured with resource capabilities"));
+		}
+
+		return Mono.defer(() -> {
+			if (this.resources.putIfAbsent(resourceHandler.resource().uri(), resourceHandler) != null) {
+				return Mono
+					.error(new McpError("Resource with URI '" + resourceHandler.resource().uri() + "' already exists"));
+			}
+			logger.info("Added resource handler: {}", resourceHandler.resource().uri());
+			if (this.serverCapabilities.resources().listChanged()) {
+				return notifyResourcesListChanged();
+			}
+			return Mono.empty();
+		});
+	}
+
+	/**
+	 * Add a new resource handler at runtime.
+	 * @param resourceHandler The resource handler to add
+	 * @return Mono that completes when clients have been notified of the change
+	 * @deprecated Use {@link #addResource(McpServerFeatures.AsyncResourceRegistration)}.
+	 */
+	@Deprecated
 	public Mono<Void> addResource(ResourceRegistration resourceHandler) {
 		if (resourceHandler == null || resourceHandler.resource() == null) {
 			return Mono.error(new McpError("Resource must not be null"));
@@ -401,7 +555,7 @@ public class McpAsyncServer {
 				.error(new McpError("Resource with URI '" + resourceHandler.resource().uri() + "' already exists"));
 		}
 
-		this.resources.put(resourceHandler.resource().uri(), resourceHandler);
+		this.resources.put(resourceHandler.resource().uri(), McpServer.mapDeprecatedResource(resourceHandler));
 		logger.info("Added resource handler: {}", resourceHandler.resource().uri());
 		if (this.serverCapabilities.resources().listChanged()) {
 			return notifyResourcesListChanged();
@@ -422,15 +576,17 @@ public class McpAsyncServer {
 			return Mono.error(new McpError("Server must be configured with resource capabilities"));
 		}
 
-		ResourceRegistration removed = this.resources.remove(resourceUri);
-		if (removed != null) {
-			logger.info("Removed resource handler: {}", resourceUri);
-			if (this.serverCapabilities.resources().listChanged()) {
-				return notifyResourcesListChanged();
+		return Mono.defer(() -> {
+			McpServerFeatures.AsyncResourceRegistration removed = this.resources.remove(resourceUri);
+			if (removed != null) {
+				logger.info("Removed resource handler: {}", resourceUri);
+				if (this.serverCapabilities.resources().listChanged()) {
+					return notifyResourcesListChanged();
+				}
+				return Mono.empty();
 			}
-			return Mono.empty();
-		}
-		return Mono.error(new McpError("Resource with URI '" + resourceUri + "' not found"));
+			return Mono.error(new McpError("Resource with URI '" + resourceUri + "' not found"));
+		});
 	}
 
 	/**
@@ -441,28 +597,30 @@ public class McpAsyncServer {
 		return this.mcpSession.sendNotification(McpSchema.METHOD_NOTIFICATION_RESOURCES_LIST_CHANGED, null);
 	}
 
-	private DefaultMcpSession.RequestHandler resourcesListRequestHandler() {
+	private DefaultMcpSession.RequestHandler<McpSchema.ListResourcesResult> resourcesListRequestHandler() {
 		return params -> {
-			var resourceList = this.resources.values().stream().map(ResourceRegistration::resource).toList();
+			var resourceList = this.resources.values()
+				.stream()
+				.map(McpServerFeatures.AsyncResourceRegistration::resource)
+				.toList();
 			return Mono.just(new McpSchema.ListResourcesResult(resourceList, null));
 		};
 	}
 
-	private DefaultMcpSession.RequestHandler resourceTemplateListRequestHandler() {
+	private DefaultMcpSession.RequestHandler<McpSchema.ListResourceTemplatesResult> resourceTemplateListRequestHandler() {
 		return params -> Mono.just(new McpSchema.ListResourceTemplatesResult(this.resourceTemplates, null));
 
 	}
 
-	private DefaultMcpSession.RequestHandler resourcesReadRequestHandler() {
+	private DefaultMcpSession.RequestHandler<McpSchema.ReadResourceResult> resourcesReadRequestHandler() {
 		return params -> {
 			McpSchema.ReadResourceRequest resourceRequest = transport.unmarshalFrom(params,
 					new TypeReference<McpSchema.ReadResourceRequest>() {
 					});
 			var resourceUri = resourceRequest.uri();
-			if (this.resources.containsKey(resourceUri)) {
-				return Mono.fromCallable(() -> this.resources.get(resourceUri).readHandler().apply(resourceRequest))
-					.map(result -> (Object) result)
-					.subscribeOn(Schedulers.boundedElastic());
+			McpServerFeatures.AsyncResourceRegistration registration = this.resources.get(resourceUri);
+			if (registration != null) {
+				return this.resources.get(resourceUri).readHandler().apply(resourceRequest);
 			}
 			return Mono.error(new McpError("Resource not found: " + resourceUri));
 		};
@@ -477,6 +635,41 @@ public class McpAsyncServer {
 	 * @param promptRegistration The prompt handler to add
 	 * @return Mono that completes when clients have been notified of the change
 	 */
+	public Mono<Void> addPrompt(McpServerFeatures.AsyncPromptRegistration promptRegistration) {
+		if (promptRegistration == null) {
+			return Mono.error(new McpError("Prompt registration must not be null"));
+		}
+		if (this.serverCapabilities.prompts() == null) {
+			return Mono.error(new McpError("Server must be configured with prompt capabilities"));
+		}
+
+		return Mono.defer(() -> {
+			McpServerFeatures.AsyncPromptRegistration registration = this.prompts
+				.putIfAbsent(promptRegistration.prompt().name(), promptRegistration);
+			if (registration != null) {
+				return Mono.error(
+						new McpError("Prompt with name '" + promptRegistration.prompt().name() + "' already exists"));
+			}
+
+			logger.info("Added prompt handler: {}", promptRegistration.prompt().name());
+
+			// Servers that declared the listChanged capability SHOULD send a
+			// notification,
+			// when the list of available prompts changes
+			if (this.serverCapabilities.prompts().listChanged()) {
+				return notifyPromptsListChanged();
+			}
+			return Mono.empty();
+		});
+	}
+
+	/**
+	 * Add a new prompt handler at runtime.
+	 * @param promptRegistration The prompt handler to add
+	 * @return Mono that completes when clients have been notified of the change
+	 * @deprecated Use {@link #addPrompt(McpServerFeatures.AsyncPromptRegistration)}.
+	 */
+	@Deprecated
 	public Mono<Void> addPrompt(PromptRegistration promptRegistration) {
 		if (promptRegistration == null) {
 			return Mono.error(new McpError("Prompt registration must not be null"));
@@ -490,7 +683,7 @@ public class McpAsyncServer {
 				.error(new McpError("Prompt with name '" + promptRegistration.prompt().name() + "' already exists"));
 		}
 
-		this.prompts.put(promptRegistration.prompt().name(), promptRegistration);
+		this.prompts.put(promptRegistration.prompt().name(), McpServer.mapDeprecatedPrompt(promptRegistration));
 
 		logger.info("Added prompt handler: {}", promptRegistration.prompt().name());
 
@@ -515,18 +708,20 @@ public class McpAsyncServer {
 			return Mono.error(new McpError("Server must be configured with prompt capabilities"));
 		}
 
-		PromptRegistration removed = this.prompts.remove(promptName);
+		return Mono.defer(() -> {
+			McpServerFeatures.AsyncPromptRegistration removed = this.prompts.remove(promptName);
 
-		if (removed != null) {
-			logger.info("Removed prompt handler: {}", promptName);
-			// Servers that declared the listChanged capability SHOULD send a
-			// notification, when the list of available prompts changes
-			if (this.serverCapabilities.prompts().listChanged()) {
-				return this.notifyPromptsListChanged();
+			if (removed != null) {
+				logger.info("Removed prompt handler: {}", promptName);
+				// Servers that declared the listChanged capability SHOULD send a
+				// notification, when the list of available prompts changes
+				if (this.serverCapabilities.prompts().listChanged()) {
+					return this.notifyPromptsListChanged();
+				}
+				return Mono.empty();
 			}
-			return Mono.empty();
-		}
-		return Mono.error(new McpError("Prompt with name '" + promptName + "' not found"));
+			return Mono.error(new McpError("Prompt with name '" + promptName + "' not found"));
+		});
 	}
 
 	/**
@@ -537,34 +732,35 @@ public class McpAsyncServer {
 		return this.mcpSession.sendNotification(McpSchema.METHOD_NOTIFICATION_PROMPTS_LIST_CHANGED, null);
 	}
 
-	private DefaultMcpSession.RequestHandler promptsListRequestHandler() {
+	private DefaultMcpSession.RequestHandler<McpSchema.ListPromptsResult> promptsListRequestHandler() {
 		return params -> {
 			// TODO: Implement pagination
 			// McpSchema.PaginatedRequest request = transport.unmarshalFrom(params,
 			// new TypeReference<McpSchema.PaginatedRequest>() {
 			// });
 
-			var promptList = this.prompts.values().stream().map(PromptRegistration::prompt).toList();
+			var promptList = this.prompts.values()
+				.stream()
+				.map(McpServerFeatures.AsyncPromptRegistration::prompt)
+				.toList();
 
 			return Mono.just(new McpSchema.ListPromptsResult(promptList, null));
 		};
 	}
 
-	private DefaultMcpSession.RequestHandler promptsGetRequestHandler() {
+	private DefaultMcpSession.RequestHandler<McpSchema.GetPromptResult> promptsGetRequestHandler() {
 		return params -> {
 			McpSchema.GetPromptRequest promptRequest = transport.unmarshalFrom(params,
 					new TypeReference<McpSchema.GetPromptRequest>() {
 					});
 
 			// Implement prompt retrieval logic here
-			if (this.prompts.containsKey(promptRequest.name())) {
-				return Mono
-					.fromCallable(() -> this.prompts.get(promptRequest.name()).promptHandler().apply(promptRequest))
-					.map(result -> (Object) result)
-					.subscribeOn(Schedulers.boundedElastic());
+			McpServerFeatures.AsyncPromptRegistration registration = this.prompts.get(promptRequest.name());
+			if (registration == null) {
+				return Mono.error(new McpError("Prompt not found: " + promptRequest.name()));
 			}
 
-			return Mono.error(new McpError("Prompt not found: " + promptRequest.name()));
+			return registration.promptHandler().apply(promptRequest);
 		};
 	}
 
@@ -600,13 +796,10 @@ public class McpAsyncServer {
 	 * not be sent.
 	 * @return A handler that processes logging level change requests
 	 */
-	private DefaultMcpSession.RequestHandler setLoggerRequestHandler() {
+	private DefaultMcpSession.RequestHandler<Void> setLoggerRequestHandler() {
 		return params -> {
-			McpSchema.LoggingLevel setLoggerRequest = transport.unmarshalFrom(params,
-					new TypeReference<McpSchema.LoggingLevel>() {
-					});
-
-			this.minLoggingLevel = setLoggerRequest;
+			this.minLoggingLevel = transport.unmarshalFrom(params, new TypeReference<LoggingLevel>() {
+			});
 
 			return Mono.empty();
 		};
@@ -615,7 +808,7 @@ public class McpAsyncServer {
 	// ---------------------------------------
 	// Sampling
 	// ---------------------------------------
-	private static TypeReference<McpSchema.CreateMessageResult> CREATE_MESSAGE_RESULT_TYPE_REF = new TypeReference<>() {
+	private static final TypeReference<McpSchema.CreateMessageResult> CREATE_MESSAGE_RESULT_TYPE_REF = new TypeReference<>() {
 	};
 
 	/**

--- a/mcp/src/main/java/org/springframework/ai/mcp/server/McpServer.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/server/McpServer.java
@@ -22,11 +22,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 
 import org.springframework.ai.mcp.spec.McpSchema;
 import org.springframework.ai.mcp.spec.McpSchema.CallToolResult;
 import org.springframework.ai.mcp.spec.McpSchema.ResourceTemplate;
-import org.springframework.ai.mcp.spec.McpSchema.Tool;
 import org.springframework.ai.mcp.spec.McpTransport;
 import org.springframework.ai.mcp.spec.ServerMcpTransport;
 import org.springframework.ai.mcp.util.Assert;
@@ -98,114 +101,803 @@ import org.springframework.ai.mcp.util.Assert;
 public interface McpServer {
 
 	/**
-	 * Registration of a tool with its handler function. Tools are the primary way for MCP
-	 * servers to expose functionality to AI models. Each tool represents a specific
-	 * capability, such as:
-	 * <ul>
-	 * <li>Performing calculations
-	 * <li>Accessing external APIs
-	 * <li>Querying databases
-	 * <li>Manipulating files
-	 * <li>Executing system commands
-	 * </ul>
-	 *
-	 * <p>
-	 * Example tool registration: <pre>{@code
-	 * new ToolRegistration(
-	 *     new Tool(
-	 *         "calculator",
-	 *         "Performs mathematical calculations",
-	 *         new JsonSchemaObject()
-	 *             .required("expression")
-	 *             .property("expression", JsonSchemaType.STRING)
-	 *     ),
-	 *     args -> {
-	 *         String expr = (String) args.get("expression");
-	 *         return new CallToolResult("Result: " + evaluate(expr));
-	 *     }
-	 * )
-	 * }</pre>
-	 *
-	 * @param tool The tool definition including name, description, and parameter schema
-	 * @param call The function that implements the tool's logic, receiving arguments and
-	 * returning results
-	 */
-	public static record ToolRegistration(Tool tool, Function<Map<String, Object>, CallToolResult> call) {
-	}
-
-	/**
-	 * Registration of a resource with its handler function. Resources provide context to
-	 * AI models by exposing data such as:
-	 * <ul>
-	 * <li>File contents
-	 * <li>Database records
-	 * <li>API responses
-	 * <li>System information
-	 * <li>Application state
-	 * </ul>
-	 *
-	 * <p>
-	 * Example resource registration: <pre>{@code
-	 * new ResourceRegistration(
-	 *     new Resource("docs", "Documentation files", "text/markdown"),
-	 *     request -> {
-	 *         String content = readFile(request.getPath());
-	 *         return new ReadResourceResult(content);
-	 *     }
-	 * )
-	 * }</pre>
-	 *
-	 * @param resource The resource definition including name, description, and MIME type
-	 * @param readHandler The function that handles resource read requests
-	 */
-	public static record ResourceRegistration(McpSchema.Resource resource,
-			Function<McpSchema.ReadResourceRequest, McpSchema.ReadResourceResult> readHandler) {
-	}
-
-	/**
-	 * Registration of a prompt template with its handler function. Prompts provide
-	 * structured templates for AI model interactions, supporting:
-	 * <ul>
-	 * <li>Consistent message formatting
-	 * <li>Parameter substitution
-	 * <li>Context injection
-	 * <li>Response formatting
-	 * <li>Instruction templating
-	 * </ul>
-	 *
-	 * <p>
-	 * Example prompt registration: <pre>{@code
-	 * new PromptRegistration(
-	 *     new Prompt("analyze", "Code analysis template"),
-	 *     request -> {
-	 *         String code = request.getArguments().get("code");
-	 *         return new GetPromptResult(
-	 *             "Analyze this code:\n\n" + code + "\n\nProvide feedback on:"
-	 *         );
-	 *     }
-	 * )
-	 * }</pre>
-	 *
-	 * @param prompt The prompt definition including name and description
-	 * @param promptHandler The function that processes prompt requests and returns
-	 * formatted templates
-	 */
-	public static record PromptRegistration(McpSchema.Prompt prompt,
-			Function<McpSchema.GetPromptRequest, McpSchema.GetPromptResult> promptHandler) {
-	}
-
-	/**
 	 * Start building an MCP server with the specified transport.
 	 * @param transport The transport layer implementation for MCP communication
 	 * @return A new builder instance
+	 * @deprecated Use {@link #sync(ServerMcpTransport)} or
+	 * {@link #async(ServerMcpTransport)} to create a server instance.
 	 */
+	@Deprecated
 	public static Builder using(ServerMcpTransport transport) {
 		return new Builder(transport);
 	}
 
 	/**
-	 * Builder class for creating MCP servers with custom configuration.
+	 * Asynchronous server specification.
 	 */
+	class AsyncSpec {
+
+		private static final McpSchema.Implementation DEFAULT_SERVER_INFO = new McpSchema.Implementation("mcp-server",
+				"1.0.0");
+
+		private final ServerMcpTransport transport;
+
+		private McpSchema.Implementation serverInfo = DEFAULT_SERVER_INFO;
+
+		private McpSchema.ServerCapabilities serverCapabilities;
+
+		/**
+		 * The Model Context Protocol (MCP) allows servers to expose tools that can be
+		 * invoked by language models. Tools enable models to interact with external
+		 * systems, such as querying databases, calling APIs, or performing computations.
+		 * Each tool is uniquely identified by a name and includes metadata describing its
+		 * schema.
+		 */
+		private final List<McpServerFeatures.AsyncToolRegistration> tools = new ArrayList<>();
+
+		/**
+		 * The Model Context Protocol (MCP) provides a standardized way for servers to
+		 * expose resources to clients. Resources allow servers to share data that
+		 * provides context to language models, such as files, database schemas, or
+		 * application-specific information. Each resource is uniquely identified by a
+		 * URI.
+		 */
+		private final Map<String, McpServerFeatures.AsyncResourceRegistration> resources = new HashMap<>();
+
+		private List<ResourceTemplate> resourceTemplates = new ArrayList<>();
+
+		/**
+		 * The Model Context Protocol (MCP) provides a standardized way for servers to
+		 * expose prompt templates to clients. Prompts allow servers to provide structured
+		 * messages and instructions for interacting with language models. Clients can
+		 * discover available prompts, retrieve their contents, and provide arguments to
+		 * customize them.
+		 */
+		private final Map<String, McpServerFeatures.AsyncPromptRegistration> prompts = new HashMap<>();
+
+		private final List<Function<List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers = new ArrayList<>();
+
+		private AsyncSpec(ServerMcpTransport transport) {
+			Assert.notNull(transport, "Transport must not be null");
+			this.transport = transport;
+		}
+
+		/**
+		 * Sets the server implementation information that will be shared with clients
+		 * during connection initialization. This helps with version compatibility,
+		 * debugging, and server identification.
+		 * @param serverInfo The server implementation details including name and version.
+		 * Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if serverInfo is null
+		 */
+		public AsyncSpec serverInfo(McpSchema.Implementation serverInfo) {
+			Assert.notNull(serverInfo, "Server info must not be null");
+			this.serverInfo = serverInfo;
+			return this;
+		}
+
+		/**
+		 * Sets the server implementation information using name and version strings. This
+		 * is a convenience method alternative to
+		 * {@link #serverInfo(McpSchema.Implementation)}.
+		 * @param name The server name. Must not be null or empty.
+		 * @param version The server version. Must not be null or empty.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if name or version is null or empty
+		 * @see #serverInfo(McpSchema.Implementation)
+		 */
+		public AsyncSpec serverInfo(String name, String version) {
+			Assert.hasText(name, "Name must not be null or empty");
+			Assert.hasText(version, "Version must not be null or empty");
+			this.serverInfo = new McpSchema.Implementation(name, version);
+			return this;
+		}
+
+		/**
+		 * Sets the server capabilities that will be advertised to clients during
+		 * connection initialization. Capabilities define what features the server
+		 * supports, such as:
+		 * <ul>
+		 * <li>Tool execution
+		 * <li>Resource access
+		 * <li>Prompt handling
+		 * <li>Streaming responses
+		 * <li>Batch operations
+		 * </ul>
+		 * @param serverCapabilities The server capabilities configuration. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if serverCapabilities is null
+		 */
+		public AsyncSpec capabilities(McpSchema.ServerCapabilities serverCapabilities) {
+			this.serverCapabilities = serverCapabilities;
+			return this;
+		}
+
+		/**
+		 * Adds a single tool with its implementation handler to the server. This is a
+		 * convenience method for registering individual tools without creating a
+		 * {@link McpServerFeatures.AsyncToolRegistration} explicitly.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .tool(
+		 *     new Tool("calculator", "Performs calculations", schema),
+		 *     args -> Mono.just(new CallToolResult("Result: " + calculate(args)))
+		 * )
+		 * }</pre>
+		 * @param tool The tool definition including name, description, and schema. Must
+		 * not be null.
+		 * @param handler The function that implements the tool's logic. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if tool or handler is null
+		 */
+		public AsyncSpec tool(McpSchema.Tool tool, Function<Map<String, Object>, Mono<CallToolResult>> handler) {
+			Assert.notNull(tool, "Tool must not be null");
+			Assert.notNull(handler, "Handler must not be null");
+
+			this.tools.add(new McpServerFeatures.AsyncToolRegistration(tool, handler));
+
+			return this;
+		}
+
+		/**
+		 * Adds multiple tools with their handlers to the server using a List. This method
+		 * is useful when tools are dynamically generated or loaded from a configuration
+		 * source.
+		 * @param toolRegistrations The list of tool registrations to add. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if toolRegistrations is null
+		 * @see #tools(McpServerFeatures.AsyncToolRegistration...)
+		 */
+		public AsyncSpec tools(List<McpServerFeatures.AsyncToolRegistration> toolRegistrations) {
+			Assert.notNull(toolRegistrations, "Tool handlers list must not be null");
+			this.tools.addAll(toolRegistrations);
+			return this;
+		}
+
+		/**
+		 * Adds multiple tools with their handlers to the server using varargs. This
+		 * method provides a convenient way to register multiple tools inline.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .tools(
+		 *     new McpServerFeatures.AsyncToolRegistration(calculatorTool, calculatorHandler),
+		 *     new McpServerFeatures.AsyncToolRegistration(weatherTool, weatherHandler),
+		 *     new McpServerFeatures.AsyncToolRegistration(fileManagerTool, fileManagerHandler)
+		 * )
+		 * }</pre>
+		 * @param toolRegistrations The tool registrations to add. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if toolRegistrations is null
+		 * @see #tools(List)
+		 */
+		public AsyncSpec tools(McpServerFeatures.AsyncToolRegistration... toolRegistrations) {
+			for (McpServerFeatures.AsyncToolRegistration tool : toolRegistrations) {
+				this.tools.add(tool);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers multiple resources with their handlers using a Map. This method is
+		 * useful when resources are dynamically generated or loaded from a configuration
+		 * source.
+		 * @param resourceRegsitrations Map of resource name to registration. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if resourceRegsitrations is null
+		 * @see #resources(McpServerFeatures.AsyncResourceRegistration...)
+		 */
+		public AsyncSpec resources(Map<String, McpServerFeatures.AsyncResourceRegistration> resourceRegsitrations) {
+			Assert.notNull(resourceRegsitrations, "Resource handlers map must not be null");
+			this.resources.putAll(resourceRegsitrations);
+			return this;
+		}
+
+		/**
+		 * Registers multiple resources with their handlers using a List. This method is
+		 * useful when resources need to be added in bulk from a collection.
+		 * @param resourceRegsitrations List of resource registrations. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if resourceRegsitrations is null
+		 * @see #resources(McpServerFeatures.AsyncResourceRegistration...)
+		 */
+		public AsyncSpec resources(List<McpServerFeatures.AsyncResourceRegistration> resourceRegsitrations) {
+			Assert.notNull(resourceRegsitrations, "Resource handlers list must not be null");
+			for (McpServerFeatures.AsyncResourceRegistration resource : resourceRegsitrations) {
+				this.resources.put(resource.resource().uri(), resource);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers multiple resources with their handlers using varargs. This method
+		 * provides a convenient way to register multiple resources inline.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .resources(
+		 *     new McpServerFeatures.AsyncResourceRegistration(fileResource, fileHandler),
+		 *     new McpServerFeatures.AsyncResourceRegistration(dbResource, dbHandler),
+		 *     new McpServerFeatures.AsyncResourceRegistration(apiResource, apiHandler)
+		 * )
+		 * }</pre>
+		 * @param resourceRegistrations The resource registrations to add. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if resourceRegistrations is null
+		 */
+		public AsyncSpec resources(McpServerFeatures.AsyncResourceRegistration... resourceRegistrations) {
+			Assert.notNull(resourceRegistrations, "Resource handlers list must not be null");
+			for (McpServerFeatures.AsyncResourceRegistration resource : resourceRegistrations) {
+				this.resources.put(resource.resource().uri(), resource);
+			}
+			return this;
+		}
+
+		/**
+		 * Sets the resource templates that define patterns for dynamic resource access.
+		 * Templates use URI patterns with placeholders that can be filled at runtime.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .resourceTemplates(
+		 *     new ResourceTemplate("file://{path}", "Access files by path"),
+		 *     new ResourceTemplate("db://{table}/{id}", "Access database records")
+		 * )
+		 * }</pre>
+		 * @param resourceTemplates List of resource templates. If null, clears existing
+		 * templates.
+		 * @return This builder instance for method chaining
+		 * @see #resourceTemplates(ResourceTemplate...)
+		 */
+		public AsyncSpec resourceTemplates(List<ResourceTemplate> resourceTemplates) {
+			this.resourceTemplates.addAll(resourceTemplates);
+			return this;
+		}
+
+		/**
+		 * Sets the resource templates using varargs for convenience. This is an
+		 * alternative to {@link #resourceTemplates(List)}.
+		 * @param resourceTemplates The resource templates to set.
+		 * @return This builder instance for method chaining
+		 * @see #resourceTemplates(List)
+		 */
+		public AsyncSpec resourceTemplates(ResourceTemplate... resourceTemplates) {
+			for (ResourceTemplate resourceTemplate : resourceTemplates) {
+				this.resourceTemplates.add(resourceTemplate);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers multiple prompts with their handlers using a Map. This method is
+		 * useful when prompts are dynamically generated or loaded from a configuration
+		 * source.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .prompts(Map.of("analysis", new McpServerFeatures.AsyncPromptRegistration(
+		 *     new Prompt("analysis", "Code analysis template"),
+		 *     request -> Mono.just(new GetPromptResult(generateAnalysisPrompt(request)))
+		 * )));
+		 * }</pre>
+		 * @param prompts Map of prompt name to registration. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if prompts is null
+		 */
+		public AsyncSpec prompts(Map<String, McpServerFeatures.AsyncPromptRegistration> prompts) {
+			this.prompts.putAll(prompts);
+			return this;
+		}
+
+		/**
+		 * Registers multiple prompts with their handlers using a List. This method is
+		 * useful when prompts need to be added in bulk from a collection.
+		 * @param prompts List of prompt registrations. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if prompts is null
+		 * @see #prompts(McpServerFeatures.AsyncPromptRegistration...)
+		 */
+		public AsyncSpec prompts(List<McpServerFeatures.AsyncPromptRegistration> prompts) {
+			for (McpServerFeatures.AsyncPromptRegistration prompt : prompts) {
+				this.prompts.put(prompt.prompt().name(), prompt);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers multiple prompts with their handlers using varargs. This method
+		 * provides a convenient way to register multiple prompts inline.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .prompts(
+		 *     new McpServerFeatures.AsyncPromptRegistration(analysisPrompt, analysisHandler),
+		 *     new McpServerFeatures.AsyncPromptRegistration(summaryPrompt, summaryHandler),
+		 *     new McpServerFeatures.AsyncPromptRegistration(reviewPrompt, reviewHandler)
+		 * )
+		 * }</pre>
+		 * @param prompts The prompt registrations to add. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if prompts is null
+		 */
+		public AsyncSpec prompts(McpServerFeatures.AsyncPromptRegistration... prompts) {
+			for (McpServerFeatures.AsyncPromptRegistration prompt : prompts) {
+				this.prompts.put(prompt.prompt().name(), prompt);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers a consumer that will be notified when the list of roots changes. This
+		 * is useful for updating resource availability dynamically, such as when new
+		 * files are added or removed.
+		 * @param consumer The consumer to register. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if consumer is null
+		 */
+		public AsyncSpec rootsChangeConsumer(Function<List<McpSchema.Root>, Mono<Void>> consumer) {
+			Assert.notNull(consumer, "Consumer must not be null");
+			this.rootsChangeConsumers.add(consumer);
+			return this;
+		}
+
+		/**
+		 * Registers multiple consumers that will be notified when the list of roots
+		 * changes. This method is useful when multiple consumers need to be registered at
+		 * once.
+		 * @param consumers The list of consumers to register. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if consumers is null
+		 */
+		public AsyncSpec rootsChangeConsumers(List<Function<List<McpSchema.Root>, Mono<Void>>> consumers) {
+			Assert.notNull(consumers, "Consumers list must not be null");
+			this.rootsChangeConsumers.addAll(consumers);
+			return this;
+		}
+
+		/**
+		 * Registers multiple consumers that will be notified when the list of roots
+		 * changes using varargs. This method provides a convenient way to register
+		 * multiple consumers inline.
+		 * @param consumers The consumers to register. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if consumers is null
+		 */
+		public AsyncSpec rootsChangeConsumers(Function<List<McpSchema.Root>, Mono<Void>>... consumers) {
+			for (Function<List<McpSchema.Root>, Mono<Void>> consumer : consumers) {
+				this.rootsChangeConsumers.add(consumer);
+			}
+			return this;
+		}
+
+		/**
+		 * Builds an asynchronous MCP server that provides non-blocking operations.
+		 * @return A new instance of {@link McpAsyncServer} configured with this builder's
+		 * settings
+		 */
+		public McpAsyncServer build() {
+			return new McpAsyncServer(this.transport,
+					new McpServerFeatures.Async(this.serverInfo, this.serverCapabilities, this.tools, this.resources,
+							this.resourceTemplates, this.prompts, this.rootsChangeConsumers));
+		}
+
+	}
+
+	/**
+	 * Synchronous server specification.
+	 */
+	class SyncSpec {
+
+		private static final McpSchema.Implementation DEFAULT_SERVER_INFO = new McpSchema.Implementation("mcp-server",
+				"1.0.0");
+
+		private final ServerMcpTransport transport;
+
+		private McpSchema.Implementation serverInfo = DEFAULT_SERVER_INFO;
+
+		private McpSchema.ServerCapabilities serverCapabilities;
+
+		/**
+		 * The Model Context Protocol (MCP) allows servers to expose tools that can be
+		 * invoked by language models. Tools enable models to interact with external
+		 * systems, such as querying databases, calling APIs, or performing computations.
+		 * Each tool is uniquely identified by a name and includes metadata describing its
+		 * schema.
+		 */
+		private final List<McpServerFeatures.SyncToolRegistration> tools = new ArrayList<>();
+
+		/**
+		 * The Model Context Protocol (MCP) provides a standardized way for servers to
+		 * expose resources to clients. Resources allow servers to share data that
+		 * provides context to language models, such as files, database schemas, or
+		 * application-specific information. Each resource is uniquely identified by a
+		 * URI.
+		 */
+		private final Map<String, McpServerFeatures.SyncResourceRegistration> resources = new HashMap<>();
+
+		private List<ResourceTemplate> resourceTemplates = new ArrayList<>();
+
+		/**
+		 * The Model Context Protocol (MCP) provides a standardized way for servers to
+		 * expose prompt templates to clients. Prompts allow servers to provide structured
+		 * messages and instructions for interacting with language models. Clients can
+		 * discover available prompts, retrieve their contents, and provide arguments to
+		 * customize them.
+		 */
+		private Map<String, McpServerFeatures.SyncPromptRegistration> prompts = new HashMap<>();
+
+		private List<Consumer<List<McpSchema.Root>>> rootsChangeConsumers = new ArrayList<>();
+
+		private SyncSpec(ServerMcpTransport transport) {
+			Assert.notNull(transport, "Transport must not be null");
+			this.transport = transport;
+		}
+
+		/**
+		 * Sets the server implementation information that will be shared with clients
+		 * during connection initialization. This helps with version compatibility,
+		 * debugging, and server identification.
+		 * @param serverInfo The server implementation details including name and version.
+		 * Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if serverInfo is null
+		 */
+		public SyncSpec serverInfo(McpSchema.Implementation serverInfo) {
+			Assert.notNull(serverInfo, "Server info must not be null");
+			this.serverInfo = serverInfo;
+			return this;
+		}
+
+		/**
+		 * Sets the server implementation information using name and version strings. This
+		 * is a convenience method alternative to
+		 * {@link #serverInfo(McpSchema.Implementation)}.
+		 * @param name The server name. Must not be null or empty.
+		 * @param version The server version. Must not be null or empty.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if name or version is null or empty
+		 * @see #serverInfo(McpSchema.Implementation)
+		 */
+		public SyncSpec serverInfo(String name, String version) {
+			Assert.hasText(name, "Name must not be null or empty");
+			Assert.hasText(version, "Version must not be null or empty");
+			this.serverInfo = new McpSchema.Implementation(name, version);
+			return this;
+		}
+
+		/**
+		 * Sets the server capabilities that will be advertised to clients during
+		 * connection initialization. Capabilities define what features the server
+		 * supports, such as:
+		 * <ul>
+		 * <li>Tool execution
+		 * <li>Resource access
+		 * <li>Prompt handling
+		 * <li>Streaming responses
+		 * <li>Batch operations
+		 * </ul>
+		 * @param serverCapabilities The server capabilities configuration. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if serverCapabilities is null
+		 */
+		public SyncSpec capabilities(McpSchema.ServerCapabilities serverCapabilities) {
+			this.serverCapabilities = serverCapabilities;
+			return this;
+		}
+
+		/**
+		 * Adds a single tool with its implementation handler to the server. This is a
+		 * convenience method for registering individual tools without creating a
+		 * {@link ToolRegistration} explicitly.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .tool(
+		 *     new Tool("calculator", "Performs calculations", schema),
+		 *     args -> new CallToolResult("Result: " + calculate(args))
+		 * )
+		 * }</pre>
+		 * @param tool The tool definition including name, description, and schema. Must
+		 * not be null.
+		 * @param handler The function that implements the tool's logic. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if tool or handler is null
+		 */
+		public SyncSpec tool(McpSchema.Tool tool, Function<Map<String, Object>, McpSchema.CallToolResult> handler) {
+			Assert.notNull(tool, "Tool must not be null");
+			Assert.notNull(handler, "Handler must not be null");
+
+			this.tools.add(new McpServerFeatures.SyncToolRegistration(tool, handler));
+
+			return this;
+		}
+
+		/**
+		 * Adds multiple tools with their handlers to the server using a List. This method
+		 * is useful when tools are dynamically generated or loaded from a configuration
+		 * source.
+		 * @param toolRegistrations The list of tool registrations to add. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if toolRegistrations is null
+		 * @see #tools(McpServerFeatures.SyncToolRegistration...)
+		 */
+		public SyncSpec tools(List<McpServerFeatures.SyncToolRegistration> toolRegistrations) {
+			Assert.notNull(toolRegistrations, "Tool handlers list must not be null");
+			this.tools.addAll(toolRegistrations);
+			return this;
+		}
+
+		/**
+		 * Adds multiple tools with their handlers to the server using varargs. This
+		 * method provides a convenient way to register multiple tools inline.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .tools(
+		 *     new ToolRegistration(calculatorTool, calculatorHandler),
+		 *     new ToolRegistration(weatherTool, weatherHandler),
+		 *     new ToolRegistration(fileManagerTool, fileManagerHandler)
+		 * )
+		 * }</pre>
+		 * @param toolRegistrations The tool registrations to add. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if toolRegistrations is null
+		 * @see #tools(List)
+		 */
+		public SyncSpec tools(McpServerFeatures.SyncToolRegistration... toolRegistrations) {
+			for (McpServerFeatures.SyncToolRegistration tool : toolRegistrations) {
+				this.tools.add(tool);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers multiple resources with their handlers using a Map. This method is
+		 * useful when resources are dynamically generated or loaded from a configuration
+		 * source.
+		 * @param resourceRegsitrations Map of resource name to registration. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if resourceRegsitrations is null
+		 * @see #resources(McpServerFeatures.SyncResourceRegistration...)
+		 */
+		public SyncSpec resources(Map<String, McpServerFeatures.SyncResourceRegistration> resourceRegsitrations) {
+			Assert.notNull(resourceRegsitrations, "Resource handlers map must not be null");
+			this.resources.putAll(resourceRegsitrations);
+			return this;
+		}
+
+		/**
+		 * Registers multiple resources with their handlers using a List. This method is
+		 * useful when resources need to be added in bulk from a collection.
+		 * @param resourceRegsitrations List of resource registrations. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if resourceRegsitrations is null
+		 * @see #resources(McpServerFeatures.SyncResourceRegistration...)
+		 */
+		public SyncSpec resources(List<McpServerFeatures.SyncResourceRegistration> resourceRegsitrations) {
+			Assert.notNull(resourceRegsitrations, "Resource handlers list must not be null");
+			for (McpServerFeatures.SyncResourceRegistration resource : resourceRegsitrations) {
+				this.resources.put(resource.resource().uri(), resource);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers multiple resources with their handlers using varargs. This method
+		 * provides a convenient way to register multiple resources inline.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .resources(
+		 *     new ResourceRegistration(fileResource, fileHandler),
+		 *     new ResourceRegistration(dbResource, dbHandler),
+		 *     new ResourceRegistration(apiResource, apiHandler)
+		 * )
+		 * }</pre>
+		 * @param resourceRegistrations The resource registrations to add. Must not be
+		 * null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if resourceRegistrations is null
+		 */
+		public SyncSpec resources(McpServerFeatures.SyncResourceRegistration... resourceRegistrations) {
+			Assert.notNull(resourceRegistrations, "Resource handlers list must not be null");
+			for (McpServerFeatures.SyncResourceRegistration resource : resourceRegistrations) {
+				this.resources.put(resource.resource().uri(), resource);
+			}
+			return this;
+		}
+
+		/**
+		 * Sets the resource templates that define patterns for dynamic resource access.
+		 * Templates use URI patterns with placeholders that can be filled at runtime.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .resourceTemplates(
+		 *     new ResourceTemplate("file://{path}", "Access files by path"),
+		 *     new ResourceTemplate("db://{table}/{id}", "Access database records")
+		 * )
+		 * }</pre>
+		 * @param resourceTemplates List of resource templates. If null, clears existing
+		 * templates.
+		 * @return This builder instance for method chaining
+		 * @see #resourceTemplates(ResourceTemplate...)
+		 */
+		public SyncSpec resourceTemplates(List<ResourceTemplate> resourceTemplates) {
+			this.resourceTemplates.addAll(resourceTemplates);
+			return this;
+		}
+
+		/**
+		 * Sets the resource templates using varargs for convenience. This is an
+		 * alternative to {@link #resourceTemplates(List)}.
+		 * @param resourceTemplates The resource templates to set.
+		 * @return This builder instance for method chaining
+		 * @see #resourceTemplates(List)
+		 */
+		public SyncSpec resourceTemplates(ResourceTemplate... resourceTemplates) {
+			for (ResourceTemplate resourceTemplate : resourceTemplates) {
+				this.resourceTemplates.add(resourceTemplate);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers multiple prompts with their handlers using a Map. This method is
+		 * useful when prompts are dynamically generated or loaded from a configuration
+		 * source.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * Map<String, PromptRegistration> prompts = new HashMap<>();
+		 * prompts.put("analysis", new PromptRegistration(
+		 *     new Prompt("analysis", "Code analysis template"),
+		 *     request -> new GetPromptResult(generateAnalysisPrompt(request))
+		 * ));
+		 * .prompts(prompts)
+		 * }</pre>
+		 * @param prompts Map of prompt name to registration. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if prompts is null
+		 */
+		public SyncSpec prompts(Map<String, McpServerFeatures.SyncPromptRegistration> prompts) {
+			this.prompts.putAll(prompts);
+			return this;
+		}
+
+		/**
+		 * Registers multiple prompts with their handlers using a List. This method is
+		 * useful when prompts need to be added in bulk from a collection.
+		 * @param prompts List of prompt registrations. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if prompts is null
+		 * @see #prompts(McpServerFeatures.SyncPromptRegistration...)
+		 */
+		public SyncSpec prompts(List<McpServerFeatures.SyncPromptRegistration> prompts) {
+			for (McpServerFeatures.SyncPromptRegistration prompt : prompts) {
+				this.prompts.put(prompt.prompt().name(), prompt);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers multiple prompts with their handlers using varargs. This method
+		 * provides a convenient way to register multiple prompts inline.
+		 *
+		 * <p>
+		 * Example usage: <pre>{@code
+		 * .prompts(
+		 *     new PromptRegistration(analysisPrompt, analysisHandler),
+		 *     new PromptRegistration(summaryPrompt, summaryHandler),
+		 *     new PromptRegistration(reviewPrompt, reviewHandler)
+		 * )
+		 * }</pre>
+		 * @param prompts The prompt registrations to add. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if prompts is null
+		 */
+		public SyncSpec prompts(McpServerFeatures.SyncPromptRegistration... prompts) {
+			for (McpServerFeatures.SyncPromptRegistration prompt : prompts) {
+				this.prompts.put(prompt.prompt().name(), prompt);
+			}
+			return this;
+		}
+
+		/**
+		 * Registers a consumer that will be notified when the list of roots changes. This
+		 * is useful for updating resource availability dynamically, such as when new
+		 * files are added or removed.
+		 * @param consumer The consumer to register. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if consumer is null
+		 */
+		public SyncSpec rootsChangeConsumer(Consumer<List<McpSchema.Root>> consumer) {
+			Assert.notNull(consumer, "Consumer must not be null");
+			this.rootsChangeConsumers.add(consumer);
+			return this;
+		}
+
+		/**
+		 * Registers multiple consumers that will be notified when the list of roots
+		 * changes. This method is useful when multiple consumers need to be registered at
+		 * once.
+		 * @param consumers The list of consumers to register. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if consumers is null
+		 */
+		public SyncSpec rootsChangeConsumers(List<Consumer<List<McpSchema.Root>>> consumers) {
+			Assert.notNull(consumers, "Consumers list must not be null");
+			this.rootsChangeConsumers.addAll(consumers);
+			return this;
+		}
+
+		/**
+		 * Registers multiple consumers that will be notified when the list of roots
+		 * changes using varargs. This method provides a convenient way to register
+		 * multiple consumers inline.
+		 * @param consumers The consumers to register. Must not be null.
+		 * @return This builder instance for method chaining
+		 * @throws IllegalArgumentException if consumers is null
+		 */
+		public SyncSpec rootsChangeConsumers(Consumer<List<McpSchema.Root>>... consumers) {
+			for (Consumer<List<McpSchema.Root>> consumer : consumers) {
+				this.rootsChangeConsumers.add(consumer);
+			}
+			return this;
+		}
+
+		/**
+		 * Builds a synchronous MCP server that provides blocking operations.
+		 * @return A new instance of {@link McpSyncServer} configured with this builder's
+		 * settings
+		 */
+		public McpSyncServer build() {
+			McpServerFeatures.Sync syncFeatures = new McpServerFeatures.Sync(this.serverInfo, this.serverCapabilities,
+					this.tools, this.resources, this.resourceTemplates, this.prompts, this.rootsChangeConsumers);
+			return new McpSyncServer(
+					new McpAsyncServer(this.transport, McpServerFeatures.Async.fromSync(syncFeatures)));
+		}
+
+	}
+
+	/**
+	 * Builds a synchronous MCP server that provides blocking operations. Synchronous
+	 * servers process each request to completion before handling the next one, making
+	 * them simpler to implement but potentially less performant for concurrent
+	 * operations.
+	 * @return A new instance of {@link SyncSpec} for configuring the server.
+	 */
+	static SyncSpec sync(ServerMcpTransport transport) {
+		return new SyncSpec(transport);
+	}
+
+	/**
+	 * Builds an asynchronous MCP server that provides blocking operations. Asynchronous
+	 * servers can handle multiple requests concurrently using a functional paradigm with
+	 * non-blocking server transports, making them more efficient for high-concurrency
+	 * scenarios but more complex to implement.
+	 * @return A new instance of {@link SyncSpec} for configuring the server.
+	 */
+	static AsyncSpec async(ServerMcpTransport transport) {
+		return new AsyncSpec(transport);
+	}
+
+	/**
+	 * Builder class for creating MCP servers with custom configuration.
+	 *
+	 * @deprecated Use {@link #sync(ServerMcpTransport)} or
+	 * {@link #async(ServerMcpTransport)} to create a server.
+	 */
+	@Deprecated
 	public static class Builder {
 
 		private static final McpSchema.Implementation DEFAULT_SERVER_INFO = new McpSchema.Implementation("mcp-server",
@@ -576,7 +1268,9 @@ public interface McpServer {
 		 * operations.
 		 * @return A new instance of {@link McpSyncServer} configured with this builder's
 		 * settings
+		 * @deprecated Use {@link #sync(ServerMcpTransport)}.
 		 */
+		@Deprecated
 		public McpSyncServer sync() {
 			return new McpSyncServer(async());
 		}
@@ -588,13 +1282,156 @@ public interface McpServer {
 		 * but more complex to implement.
 		 * @return A new instance of {@link McpAsyncServer} configured with this builder's
 		 * settings
+		 * @deprecated Use {@link #async(ServerMcpTransport)}
 		 */
+		@Deprecated
 		public McpAsyncServer async() {
-
 			return new McpAsyncServer(transport, serverInfo, serverCapabilities, tools, resources, resourceTemplates,
 					prompts, rootsChangeConsumers);
 		}
 
+	}
+
+	/**
+	 * Registration of a tool with its handler function. Tools are the primary way for MCP
+	 * servers to expose functionality to AI models. Each tool represents a specific
+	 * capability, such as:
+	 * <ul>
+	 * <li>Performing calculations
+	 * <li>Accessing external APIs
+	 * <li>Querying databases
+	 * <li>Manipulating files
+	 * <li>Executing system commands
+	 * </ul>
+	 *
+	 * <p>
+	 * Example tool registration: <pre>{@code
+	 * new ToolRegistration(
+	 *     new Tool(
+	 *         "calculator",
+	 *         "Performs mathematical calculations",
+	 *         new JsonSchemaObject()
+	 *             .required("expression")
+	 *             .property("expression", JsonSchemaType.STRING)
+	 *     ),
+	 *     args -> {
+	 *         String expr = (String) args.get("expression");
+	 *         return new CallToolResult("Result: " + evaluate(expr));
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param tool The tool definition including name, description, and parameter schema
+	 * @param call The function that implements the tool's logic, receiving arguments and
+	 * returning results
+	 * @deprecated Use {@link McpServerFeatures.SyncToolRegistration} or
+	 * {@link McpServerFeatures.AsyncToolRegistration}.
+	 */
+	@Deprecated
+	public static record ToolRegistration(McpSchema.Tool tool,
+			Function<Map<String, Object>, McpSchema.CallToolResult> call) {
+	}
+
+	/**
+	 * Registration of a resource with its handler function. Resources provide context to
+	 * AI models by exposing data such as:
+	 * <ul>
+	 * <li>File contents
+	 * <li>Database records
+	 * <li>API responses
+	 * <li>System information
+	 * <li>Application state
+	 * </ul>
+	 *
+	 * <p>
+	 * Example resource registration: <pre>{@code
+	 * new ResourceRegistration(
+	 *     new Resource("docs", "Documentation files", "text/markdown"),
+	 *     request -> {
+	 *         String content = readFile(request.getPath());
+	 *         return new ReadResourceResult(content);
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param resource The resource definition including name, description, and MIME type
+	 * @param readHandler The function that handles resource read requests
+	 * @deprecated Use {@link McpServerFeatures.SyncResourceRegistration} or
+	 * {@link McpServerFeatures.AsyncResourceRegistration}.
+	 */
+	@Deprecated
+	public static record ResourceRegistration(McpSchema.Resource resource,
+			Function<McpSchema.ReadResourceRequest, McpSchema.ReadResourceResult> readHandler) {
+	}
+
+	/**
+	 * Registration of a prompt template with its handler function. Prompts provide
+	 * structured templates for AI model interactions, supporting:
+	 * <ul>
+	 * <li>Consistent message formatting
+	 * <li>Parameter substitution
+	 * <li>Context injection
+	 * <li>Response formatting
+	 * <li>Instruction templating
+	 * </ul>
+	 *
+	 * <p>
+	 * Example prompt registration: <pre>{@code
+	 * new PromptRegistration(
+	 *     new Prompt("analyze", "Code analysis template"),
+	 *     request -> {
+	 *         String code = request.getArguments().get("code");
+	 *         return new GetPromptResult(
+	 *             "Analyze this code:\n\n" + code + "\n\nProvide feedback on:"
+	 *         );
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param prompt The prompt definition including name and description
+	 * @param promptHandler The function that processes prompt requests and returns
+	 * formatted templates
+	 * @deprecated Use {@link McpServerFeatures.SyncPromptRegistration} or
+	 * {@link McpServerFeatures.AsyncPromptRegistration}.
+	 */
+	@Deprecated
+	public static record PromptRegistration(McpSchema.Prompt prompt,
+			Function<McpSchema.GetPromptRequest, McpSchema.GetPromptResult> promptHandler) {
+	}
+
+	static McpServerFeatures.AsyncToolRegistration mapDeprecatedTool(ToolRegistration oldTool) {
+		return new McpServerFeatures.AsyncToolRegistration(oldTool.tool(),
+				map -> Mono.fromCallable(() -> oldTool.call().apply(map)).subscribeOn(Schedulers.boundedElastic()));
+	}
+
+	static McpServerFeatures.AsyncResourceRegistration mapDeprecatedResource(ResourceRegistration oldResource) {
+		return new McpServerFeatures.AsyncResourceRegistration(oldResource.resource(),
+				req -> Mono.fromCallable(() -> oldResource.readHandler().apply(req))
+					.subscribeOn(Schedulers.boundedElastic()));
+	}
+
+	static McpServerFeatures.AsyncPromptRegistration mapDeprecatedPrompt(PromptRegistration oldPrompt) {
+		return new McpServerFeatures.AsyncPromptRegistration(oldPrompt.prompt(),
+				req -> Mono.fromCallable(() -> oldPrompt.promptHandler().apply(req))
+					.subscribeOn(Schedulers.boundedElastic()));
+	}
+
+	static List<McpServerFeatures.AsyncToolRegistration> mapDeprecatedTools(List<ToolRegistration> oldTools) {
+		return oldTools.stream().map(McpServer::mapDeprecatedTool).toList();
+	}
+
+	static Map<String, McpServerFeatures.AsyncResourceRegistration> mapDeprecatedResources(
+			Map<String, ResourceRegistration> oldResources) {
+		return oldResources.entrySet()
+			.stream()
+			.collect(Collectors.toMap(Map.Entry::getKey, e -> mapDeprecatedResource(e.getValue())));
+	}
+
+	static Map<String, McpServerFeatures.AsyncPromptRegistration> mapDeprecatedPrompts(
+			Map<String, PromptRegistration> oldPrompts) {
+		return oldPrompts.entrySet()
+			.stream()
+			.collect(Collectors.toMap(Map.Entry::getKey, e -> mapDeprecatedPrompt(e.getValue())));
 	}
 
 }

--- a/mcp/src/main/java/org/springframework/ai/mcp/server/McpServerFeatures.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/server/McpServerFeatures.java
@@ -1,0 +1,399 @@
+package org.springframework.ai.mcp.server;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+import org.springframework.ai.mcp.spec.McpSchema;
+import org.springframework.ai.mcp.util.Assert;
+import org.springframework.ai.mcp.util.Utils;
+
+/**
+ * MCP server features specification that a particular server can choose to support.
+ */
+public class McpServerFeatures {
+
+	/**
+	 * Asynchronous server features specification.
+	 *
+	 * @param serverInfo The server implementation details
+	 * @param serverCapabilities The server capabilities
+	 * @param tools The list of tool registrations
+	 * @param resources The map of resource registrations
+	 * @param resourceTemplates The list of resource templates
+	 * @param prompts The map of prompt registrations
+	 * @param rootsChangeConsumers The list of consumers that will be notified when the
+	 * roots list changes
+	 */
+	record Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
+			List<McpServerFeatures.AsyncToolRegistration> tools, Map<String, AsyncResourceRegistration> resources,
+			List<McpSchema.ResourceTemplate> resourceTemplates,
+			Map<String, McpServerFeatures.AsyncPromptRegistration> prompts,
+			List<Function<List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers) {
+
+		/**
+		 * Create an instance and validate the arguments.
+		 * @param serverInfo The server implementation details
+		 * @param serverCapabilities The server capabilities
+		 * @param tools The list of tool registrations
+		 * @param resources The map of resource registrations
+		 * @param resourceTemplates The list of resource templates
+		 * @param prompts The map of prompt registrations
+		 * @param rootsChangeConsumers The list of consumers that will be notified when
+		 * the roots list changes
+		 */
+		Async(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
+				List<McpServerFeatures.AsyncToolRegistration> tools, Map<String, AsyncResourceRegistration> resources,
+				List<McpSchema.ResourceTemplate> resourceTemplates,
+				Map<String, McpServerFeatures.AsyncPromptRegistration> prompts,
+				List<Function<List<McpSchema.Root>, Mono<Void>>> rootsChangeConsumers) {
+
+			Assert.notNull(serverInfo, "Server info must not be null");
+
+			this.serverInfo = serverInfo;
+			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
+					: new McpSchema.ServerCapabilities(null, // experimental
+							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
+																					// logging
+																					// by
+																					// default
+							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
+							!Utils.isEmpty(resources)
+									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,
+							!Utils.isEmpty(tools) ? new McpSchema.ServerCapabilities.ToolCapabilities(false) : null);
+
+			this.tools = (tools != null) ? tools : List.of();
+			this.resources = (resources != null) ? resources : Map.of();
+			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : List.of();
+			this.prompts = (prompts != null) ? prompts : Map.of();
+			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : List.of();
+		}
+
+		/**
+		 * Convert a synchronous specification into an asynchronous one and provide
+		 * blocking code offloading to prevent accidental blocking of the non-blocking
+		 * transport.
+		 * @param syncSpec a potentially blocking, synchronous specification.
+		 * @return a specification which is protected from blocking calls specified by the
+		 * user.
+		 */
+		static Async fromSync(Sync syncSpec) {
+			List<McpServerFeatures.AsyncToolRegistration> tools = new ArrayList<>();
+			for (var tool : syncSpec.tools()) {
+				tools.add(AsyncToolRegistration.fromSync(tool));
+			}
+
+			Map<String, AsyncResourceRegistration> resources = new HashMap<>();
+			syncSpec.resources().forEach((key, resource) -> {
+				resources.put(key, AsyncResourceRegistration.fromSync(resource));
+			});
+
+			Map<String, AsyncPromptRegistration> prompts = new HashMap<>();
+			syncSpec.prompts().forEach((key, prompt) -> {
+				prompts.put(key, AsyncPromptRegistration.fromSync(prompt));
+			});
+
+			List<Function<List<McpSchema.Root>, Mono<Void>>> rootChangeConsumers = new ArrayList<>();
+
+			for (var rootChangeConsumer : syncSpec.rootsChangeConsumers()) {
+				rootChangeConsumers.add(list -> Mono.<Void>fromRunnable(() -> rootChangeConsumer.accept(list))
+					.subscribeOn(Schedulers.boundedElastic()));
+			}
+
+			return new Async(syncSpec.serverInfo(), syncSpec.serverCapabilities(), tools, resources,
+					syncSpec.resourceTemplates(), prompts, rootChangeConsumers);
+		}
+	}
+
+	/**
+	 * Synchronous server features specification.
+	 *
+	 * @param serverInfo The server implementation details
+	 * @param serverCapabilities The server capabilities
+	 * @param tools The list of tool registrations
+	 * @param resources The map of resource registrations
+	 * @param resourceTemplates The list of resource templates
+	 * @param prompts The map of prompt registrations
+	 * @param rootsChangeConsumers The list of consumers that will be notified when the
+	 * roots list changes
+	 */
+	record Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
+			List<McpServerFeatures.SyncToolRegistration> tools,
+			Map<String, McpServerFeatures.SyncResourceRegistration> resources,
+			List<McpSchema.ResourceTemplate> resourceTemplates,
+			Map<String, McpServerFeatures.SyncPromptRegistration> prompts,
+			List<Consumer<List<McpSchema.Root>>> rootsChangeConsumers) {
+
+		/**
+		 * Create an instance and validate the arguments.
+		 * @param serverInfo The server implementation details
+		 * @param serverCapabilities The server capabilities
+		 * @param tools The list of tool registrations
+		 * @param resources The map of resource registrations
+		 * @param resourceTemplates The list of resource templates
+		 * @param prompts The map of prompt registrations
+		 * @param rootsChangeConsumers The list of consumers that will be notified when
+		 * the roots list changes
+		 */
+		Sync(McpSchema.Implementation serverInfo, McpSchema.ServerCapabilities serverCapabilities,
+				List<McpServerFeatures.SyncToolRegistration> tools,
+				Map<String, McpServerFeatures.SyncResourceRegistration> resources,
+				List<McpSchema.ResourceTemplate> resourceTemplates,
+				Map<String, McpServerFeatures.SyncPromptRegistration> prompts,
+				List<Consumer<List<McpSchema.Root>>> rootsChangeConsumers) {
+
+			Assert.notNull(serverInfo, "Server info must not be null");
+
+			this.serverInfo = serverInfo;
+			this.serverCapabilities = (serverCapabilities != null) ? serverCapabilities
+					: new McpSchema.ServerCapabilities(null, // experimental
+							new McpSchema.ServerCapabilities.LoggingCapabilities(), // Enable
+																					// logging
+																					// by
+																					// default
+							!Utils.isEmpty(prompts) ? new McpSchema.ServerCapabilities.PromptCapabilities(false) : null,
+							!Utils.isEmpty(resources)
+									? new McpSchema.ServerCapabilities.ResourceCapabilities(false, false) : null,
+							!Utils.isEmpty(tools) ? new McpSchema.ServerCapabilities.ToolCapabilities(false) : null);
+
+			this.tools = (tools != null) ? tools : new ArrayList<>();
+			this.resources = (resources != null) ? resources : new HashMap<>();
+			this.resourceTemplates = (resourceTemplates != null) ? resourceTemplates : new ArrayList<>();
+			this.prompts = (prompts != null) ? prompts : new HashMap<>();
+			this.rootsChangeConsumers = (rootsChangeConsumers != null) ? rootsChangeConsumers : new ArrayList<>();
+		}
+
+	}
+
+	/**
+	 * Registration of a tool with its asynchronous handler function. Tools are the
+	 * primary way for MCP servers to expose functionality to AI models. Each tool
+	 * represents a specific capability, such as:
+	 * <ul>
+	 * <li>Performing calculations
+	 * <li>Accessing external APIs
+	 * <li>Querying databases
+	 * <li>Manipulating files
+	 * <li>Executing system commands
+	 * </ul>
+	 *
+	 * <p>
+	 * Example tool registration: <pre>{@code
+	 * new McpServerFeatures.AsyncToolRegistration(
+	 *     new Tool(
+	 *         "calculator",
+	 *         "Performs mathematical calculations",
+	 *         new JsonSchemaObject()
+	 *             .required("expression")
+	 *             .property("expression", JsonSchemaType.STRING)
+	 *     ),
+	 *     args -> {
+	 *         String expr = (String) args.get("expression");
+	 *         return Mono.just(new CallToolResult("Result: " + evaluate(expr)));
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param tool The tool definition including name, description, and parameter schema
+	 * @param call The function that implements the tool's logic, receiving arguments and
+	 * returning results
+	 */
+	public record AsyncToolRegistration(McpSchema.Tool tool,
+			Function<Map<String, Object>, Mono<McpSchema.CallToolResult>> call) {
+
+		static AsyncToolRegistration fromSync(SyncToolRegistration tool) {
+			// FIXME: This is temporary, proper validation should be implemented
+			if (tool == null) {
+				return null;
+			}
+			return new AsyncToolRegistration(tool.tool(),
+					map -> Mono.fromCallable(() -> tool.call().apply(map)).subscribeOn(Schedulers.boundedElastic()));
+		}
+	}
+
+	/**
+	 * Registration of a resource with its asynchronous handler function. Resources
+	 * provide context to AI models by exposing data such as:
+	 * <ul>
+	 * <li>File contents
+	 * <li>Database records
+	 * <li>API responses
+	 * <li>System information
+	 * <li>Application state
+	 * </ul>
+	 *
+	 * <p>
+	 * Example resource registration: <pre>{@code
+	 * new McpServerFeatures.AsyncResourceRegistration(
+	 *     new Resource("docs", "Documentation files", "text/markdown"),
+	 *     request -> {
+	 *         String content = readFile(request.getPath());
+	 *         return Mono.just(new ReadResourceResult(content));
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param resource The resource definition including name, description, and MIME type
+	 * @param readHandler The function that handles resource read requests
+	 */
+	public record AsyncResourceRegistration(McpSchema.Resource resource,
+			Function<McpSchema.ReadResourceRequest, Mono<McpSchema.ReadResourceResult>> readHandler) {
+
+		static AsyncResourceRegistration fromSync(SyncResourceRegistration resource) {
+			// FIXME: This is temporary, proper validation should be implemented
+			if (resource == null) {
+				return null;
+			}
+			return new AsyncResourceRegistration(resource.resource(),
+					req -> Mono.fromCallable(() -> resource.readHandler().apply(req))
+						.subscribeOn(Schedulers.boundedElastic()));
+		}
+	}
+
+	/**
+	 * Registration of a prompt template with its asynchronous handler function. Prompts
+	 * provide structured templates for AI model interactions, supporting:
+	 * <ul>
+	 * <li>Consistent message formatting
+	 * <li>Parameter substitution
+	 * <li>Context injection
+	 * <li>Response formatting
+	 * <li>Instruction templating
+	 * </ul>
+	 *
+	 * <p>
+	 * Example prompt registration: <pre>{@code
+	 * new McpServerFeatures.AsyncPromptRegistration(
+	 *     new Prompt("analyze", "Code analysis template"),
+	 *     request -> {
+	 *         String code = request.getArguments().get("code");
+	 *         return Mono.just(new GetPromptResult(
+	 *             "Analyze this code:\n\n" + code + "\n\nProvide feedback on:"
+	 *         ));
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param prompt The prompt definition including name and description
+	 * @param promptHandler The function that processes prompt requests and returns
+	 * formatted templates
+	 */
+	public record AsyncPromptRegistration(McpSchema.Prompt prompt,
+			Function<McpSchema.GetPromptRequest, Mono<McpSchema.GetPromptResult>> promptHandler) {
+
+		static AsyncPromptRegistration fromSync(SyncPromptRegistration prompt) {
+			// FIXME: This is temporary, proper validation should be implemented
+			if (prompt == null) {
+				return null;
+			}
+			return new AsyncPromptRegistration(prompt.prompt(),
+					req -> Mono.fromCallable(() -> prompt.promptHandler().apply(req))
+						.subscribeOn(Schedulers.boundedElastic()));
+		}
+	}
+
+	/**
+	 * Registration of a tool with its synchronous handler function. Tools are the primary
+	 * way for MCP servers to expose functionality to AI models. Each tool represents a
+	 * specific capability, such as:
+	 * <ul>
+	 * <li>Performing calculations
+	 * <li>Accessing external APIs
+	 * <li>Querying databases
+	 * <li>Manipulating files
+	 * <li>Executing system commands
+	 * </ul>
+	 *
+	 * <p>
+	 * Example tool registration: <pre>{@code
+	 * new McpServerFeatures.SyncToolRegistration(
+	 *     new Tool(
+	 *         "calculator",
+	 *         "Performs mathematical calculations",
+	 *         new JsonSchemaObject()
+	 *             .required("expression")
+	 *             .property("expression", JsonSchemaType.STRING)
+	 *     ),
+	 *     args -> {
+	 *         String expr = (String) args.get("expression");
+	 *         return new CallToolResult("Result: " + evaluate(expr));
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param tool The tool definition including name, description, and parameter schema
+	 * @param call The function that implements the tool's logic, receiving arguments and
+	 * returning results
+	 */
+	public record SyncToolRegistration(McpSchema.Tool tool,
+			Function<Map<String, Object>, McpSchema.CallToolResult> call) {
+	}
+
+	/**
+	 * Registration of a resource with its synchronous handler function. Resources provide
+	 * context to AI models by exposing data such as:
+	 * <ul>
+	 * <li>File contents
+	 * <li>Database records
+	 * <li>API responses
+	 * <li>System information
+	 * <li>Application state
+	 * </ul>
+	 *
+	 * <p>
+	 * Example resource registration: <pre>{@code
+	 * new McpServerFeatures.SyncResourceRegistration(
+	 *     new Resource("docs", "Documentation files", "text/markdown"),
+	 *     request -> {
+	 *         String content = readFile(request.getPath());
+	 *         return new ReadResourceResult(content);
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param resource The resource definition including name, description, and MIME type
+	 * @param readHandler The function that handles resource read requests
+	 */
+	public record SyncResourceRegistration(McpSchema.Resource resource,
+			Function<McpSchema.ReadResourceRequest, McpSchema.ReadResourceResult> readHandler) {
+	}
+
+	/**
+	 * Registration of a prompt template with its synchronous handler function. Prompts
+	 * provide structured templates for AI model interactions, supporting:
+	 * <ul>
+	 * <li>Consistent message formatting
+	 * <li>Parameter substitution
+	 * <li>Context injection
+	 * <li>Response formatting
+	 * <li>Instruction templating
+	 * </ul>
+	 *
+	 * <p>
+	 * Example prompt registration: <pre>{@code
+	 * new McpServerFeatures.SyncPromptRegistration(
+	 *     new Prompt("analyze", "Code analysis template"),
+	 *     request -> {
+	 *         String code = request.getArguments().get("code");
+	 *         return new GetPromptResult(
+	 *             "Analyze this code:\n\n" + code + "\n\nProvide feedback on:"
+	 *         );
+	 *     }
+	 * )
+	 * }</pre>
+	 *
+	 * @param prompt The prompt definition including name and description
+	 * @param promptHandler The function that processes prompt requests and returns
+	 * formatted templates
+	 */
+	public record SyncPromptRegistration(McpSchema.Prompt prompt,
+			Function<McpSchema.GetPromptRequest, McpSchema.GetPromptResult> promptHandler) {
+	}
+
+}

--- a/mcp/src/main/java/org/springframework/ai/mcp/server/McpSyncServer.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/server/McpSyncServer.java
@@ -69,6 +69,16 @@ public class McpSyncServer {
 	 * Add a new tool handler.
 	 * @param toolHandler The tool handler to add
 	 */
+	public void addTool(McpServerFeatures.SyncToolRegistration toolHandler) {
+		this.asyncServer.addTool(McpServerFeatures.AsyncToolRegistration.fromSync(toolHandler)).block();
+	}
+
+	/**
+	 * Add a new tool handler.
+	 * @param toolHandler The tool handler to add
+	 * @deprecated Use {@link #addTool(McpServerFeatures.SyncToolRegistration)}.
+	 */
+	@Deprecated
 	public void addTool(ToolRegistration toolHandler) {
 		this.asyncServer.addTool(toolHandler).block();
 	}
@@ -85,6 +95,16 @@ public class McpSyncServer {
 	 * Add a new resource handler.
 	 * @param resourceHandler The resource handler to add
 	 */
+	public void addResource(McpServerFeatures.SyncResourceRegistration resourceHandler) {
+		this.asyncServer.addResource(McpServerFeatures.AsyncResourceRegistration.fromSync(resourceHandler)).block();
+	}
+
+	/**
+	 * Add a new resource handler.
+	 * @param resourceHandler The resource handler to add
+	 * @deprecated Use {@link #addResource(McpServerFeatures.SyncResourceRegistration)}.
+	 */
+	@Deprecated
 	public void addResource(ResourceRegistration resourceHandler) {
 		this.asyncServer.addResource(resourceHandler).block();
 	}
@@ -101,6 +121,16 @@ public class McpSyncServer {
 	 * Add a new prompt handler.
 	 * @param promptRegistration The prompt registration to add
 	 */
+	public void addPrompt(McpServerFeatures.SyncPromptRegistration promptRegistration) {
+		this.asyncServer.addPrompt(McpServerFeatures.AsyncPromptRegistration.fromSync(promptRegistration)).block();
+	}
+
+	/**
+	 * Add a new prompt handler.
+	 * @param promptRegistration The prompt registration to add
+	 * @deprecated Use {@link #addPrompt(McpServerFeatures.SyncPromptRegistration)}.
+	 */
+	@Deprecated
 	public void addPrompt(PromptRegistration promptRegistration) {
 		this.asyncServer.addPrompt(promptRegistration).block();
 	}

--- a/mcp/src/main/java/org/springframework/ai/mcp/spec/DefaultMcpSession.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/spec/DefaultMcpSession.java
@@ -63,7 +63,7 @@ public class DefaultMcpSession implements McpSession {
 	private final ConcurrentHashMap<Object, MonoSink<McpSchema.JSONRPCResponse>> pendingResponses = new ConcurrentHashMap<>();
 
 	/** Map of request handlers keyed by method name */
-	private final ConcurrentHashMap<String, RequestHandler> requestHandlers = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, RequestHandler<?>> requestHandlers = new ConcurrentHashMap<>();
 
 	/** Map of notification handlers keyed by method name */
 	private final ConcurrentHashMap<String, NotificationHandler> notificationHandlers = new ConcurrentHashMap<>();
@@ -79,16 +79,18 @@ public class DefaultMcpSession implements McpSession {
 	/**
 	 * Functional interface for handling incoming JSON-RPC requests. Implementations
 	 * should process the request parameters and return a response.
+	 *
+	 * @param <T> Response type
 	 */
 	@FunctionalInterface
-	public interface RequestHandler {
+	public interface RequestHandler<T> {
 
 		/**
 		 * Handles an incoming request with the given parameters.
 		 * @param params The request parameters
 		 * @return A Mono containing the response object
 		 */
-		Mono<Object> handle(Object params);
+		Mono<T> handle(Object params);
 
 	}
 
@@ -116,7 +118,7 @@ public class DefaultMcpSession implements McpSession {
 	 * @param notificationHandlers Map of method names to notification handlers
 	 */
 	public DefaultMcpSession(Duration requestTimeout, McpTransport transport,
-			Map<String, RequestHandler> requestHandlers, Map<String, NotificationHandler> notificationHandlers) {
+			Map<String, RequestHandler<?>> requestHandlers, Map<String, NotificationHandler> notificationHandlers) {
 
 		Assert.notNull(requestTimeout, "The requstTimeout can not be null");
 		Assert.notNull(transport, "The transport can not be null");

--- a/mcp/src/test/java/org/springframework/ai/mcp/client/AbstractMcpAsyncClientTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/client/AbstractMcpAsyncClientTests.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import org.springframework.ai.mcp.spec.ClientMcpTransport;
@@ -77,10 +78,10 @@ public abstract class AbstractMcpAsyncClientTests {
 		this.mcpTransport = createMcpTransport();
 
 		assertThatCode(() -> {
-			mcpAsyncClient = McpClient.using(mcpTransport)
+			mcpAsyncClient = McpClient.async(mcpTransport)
 				.requestTimeout(TIMEOUT)
 				.capabilities(ClientCapabilities.builder().roots(true).build())
-				.async();
+				.build();
 			mcpAsyncClient.initialize().block(Duration.ofSeconds(10));
 		}).doesNotThrowAnyException();
 	}
@@ -96,10 +97,10 @@ public abstract class AbstractMcpAsyncClientTests {
 
 	@Test
 	void testConstructorWithInvalidArguments() {
-		assertThatThrownBy(() -> McpClient.using(null).sync()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> McpClient.sync(null).build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Transport must not be null");
 
-		assertThatThrownBy(() -> McpClient.using(mcpTransport).requestTimeout(null).sync())
+		assertThatThrownBy(() -> McpClient.sync(mcpTransport).requestTimeout(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Request timeout must not be null");
 	}
@@ -195,10 +196,10 @@ public abstract class AbstractMcpAsyncClientTests {
 	void testInitializeWithRootsListProviders() {
 		var transport = createMcpTransport();
 
-		var client = McpClient.using(transport)
+		var client = McpClient.async(transport)
 			.requestTimeout(TIMEOUT)
 			.roots(new Root("file:///test/path", "test-root"))
-			.async();
+			.build();
 
 		assertThatCode(() -> client.initialize().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 
@@ -277,12 +278,12 @@ public abstract class AbstractMcpAsyncClientTests {
 		AtomicBoolean promptsNotificationReceived = new AtomicBoolean(false);
 
 		var transport = createMcpTransport();
-		var client = McpClient.using(transport)
+		var client = McpClient.async(transport)
 			.requestTimeout(TIMEOUT)
-			.toolsChangeConsumer(tools -> toolsNotificationReceived.set(true))
-			.resourcesChangeConsumer(resources -> resourcesNotificationReceived.set(true))
-			.promptsChangeConsumer(prompts -> promptsNotificationReceived.set(true))
-			.async();
+			.toolsChangeConsumer(tools -> Mono.fromRunnable(() -> toolsNotificationReceived.set(true)))
+			.resourcesChangeConsumer(resources -> Mono.fromRunnable(() -> resourcesNotificationReceived.set(true)))
+			.promptsChangeConsumer(prompts -> Mono.fromRunnable(() -> promptsNotificationReceived.set(true)))
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize().block();
@@ -299,9 +300,11 @@ public abstract class AbstractMcpAsyncClientTests {
 
 		var capabilities = ClientCapabilities.builder().sampling().build();
 
-		var client = McpClient.using(transport).requestTimeout(TIMEOUT).capabilities(capabilities).sampling(request -> {
-			return CreateMessageResult.builder().message("test").model("test-model").build();
-		}).async();
+		var client = McpClient.async(transport)
+			.requestTimeout(TIMEOUT)
+			.capabilities(capabilities)
+			.sampling(request -> Mono.just(CreateMessageResult.builder().message("test").model("test-model").build()))
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize().block(Duration.ofSeconds(10));
@@ -319,14 +322,13 @@ public abstract class AbstractMcpAsyncClientTests {
 			.sampling()
 			.build();
 
-		Function<CreateMessageRequest, CreateMessageResult> samplingHandler = request -> {
-			return CreateMessageResult.builder().message("test").model("test-model").build();
-		};
-		var client = McpClient.using(transport)
+		Function<CreateMessageRequest, Mono<CreateMessageResult>> samplingHandler = request -> Mono
+			.just(CreateMessageResult.builder().message("test").model("test-model").build());
+		var client = McpClient.async(transport)
 			.requestTimeout(TIMEOUT)
 			.capabilities(capabilities)
 			.sampling(samplingHandler)
-			.async();
+			.build();
 
 		assertThatCode(() -> {
 			var result = client.initialize().block(Duration.ofSeconds(10));
@@ -353,10 +355,10 @@ public abstract class AbstractMcpAsyncClientTests {
 		AtomicBoolean logReceived = new AtomicBoolean(false);
 		var transport = createMcpTransport();
 
-		var client = McpClient.using(transport)
+		var client = McpClient.async(transport)
 			.requestTimeout(TIMEOUT)
-			.loggingConsumer(notification -> logReceived.set(true))
-			.async();
+			.loggingConsumer(notification -> Mono.fromRunnable(() -> logReceived.set(true)))
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize().block(Duration.ofSeconds(10));

--- a/mcp/src/test/java/org/springframework/ai/mcp/client/AbstractMcpSyncClientTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/client/AbstractMcpSyncClientTests.java
@@ -72,10 +72,10 @@ public abstract class AbstractMcpSyncClientTests {
 		this.mcpTransport = createMcpTransport();
 
 		assertThatCode(() -> {
-			mcpSyncClient = McpClient.using(mcpTransport)
+			mcpSyncClient = McpClient.sync(mcpTransport)
 				.requestTimeout(TIMEOUT)
 				.capabilities(ClientCapabilities.builder().roots(true).build())
-				.sync();
+				.build();
 			mcpSyncClient.initialize();
 		}).doesNotThrowAnyException();
 	}
@@ -90,10 +90,10 @@ public abstract class AbstractMcpSyncClientTests {
 
 	@Test
 	void testConstructorWithInvalidArguments() {
-		assertThatThrownBy(() -> McpClient.using(null).sync()).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> McpClient.sync(null).build()).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Transport must not be null");
 
-		assertThatThrownBy(() -> McpClient.using(mcpTransport).requestTimeout(null).sync())
+		assertThatThrownBy(() -> McpClient.sync(mcpTransport).requestTimeout(null).build())
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Request timeout must not be null");
 	}
@@ -180,10 +180,10 @@ public abstract class AbstractMcpSyncClientTests {
 	void testInitializeWithRootsListProviders() {
 		var transport = createMcpTransport();
 
-		var client = McpClient.using(transport)
+		var client = McpClient.sync(transport)
 			.requestTimeout(TIMEOUT)
 			.roots(new Root("file:///test/path", "test-root"))
-			.sync();
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize();
@@ -262,12 +262,12 @@ public abstract class AbstractMcpSyncClientTests {
 		AtomicBoolean promptsNotificationReceived = new AtomicBoolean(false);
 
 		var transport = createMcpTransport();
-		var client = McpClient.using(transport)
+		var client = McpClient.sync(transport)
 			.requestTimeout(TIMEOUT)
 			.toolsChangeConsumer(tools -> toolsNotificationReceived.set(true))
 			.resourcesChangeConsumer(resources -> resourcesNotificationReceived.set(true))
 			.promptsChangeConsumer(prompts -> promptsNotificationReceived.set(true))
-			.sync();
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize();
@@ -295,10 +295,10 @@ public abstract class AbstractMcpSyncClientTests {
 		AtomicBoolean logReceived = new AtomicBoolean(false);
 		var transport = createMcpTransport();
 
-		var client = McpClient.using(transport)
+		var client = McpClient.sync(transport)
 			.requestTimeout(TIMEOUT)
 			.loggingConsumer(notification -> logReceived.set(true))
-			.sync();
+			.build();
 
 		assertThatCode(() -> {
 			client.initialize();

--- a/mcp/src/test/java/org/springframework/ai/mcp/server/AbstractMcpAsyncServerTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/server/AbstractMcpAsyncServerTests.java
@@ -22,11 +22,9 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
-import org.springframework.ai.mcp.server.McpServer.PromptRegistration;
-import org.springframework.ai.mcp.server.McpServer.ResourceRegistration;
-import org.springframework.ai.mcp.server.McpServer.ToolRegistration;
 import org.springframework.ai.mcp.spec.McpError;
 import org.springframework.ai.mcp.spec.McpSchema;
 import org.springframework.ai.mcp.spec.McpSchema.CallToolResult;
@@ -81,24 +79,24 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testConstructorWithInvalidArguments() {
-		assertThatThrownBy(() -> McpServer.using(null)).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> McpServer.async(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Transport must not be null");
 
-		assertThatThrownBy(() -> McpServer.using(createMcpTransport()).serverInfo((McpSchema.Implementation) null))
+		assertThatThrownBy(() -> McpServer.async(createMcpTransport()).serverInfo((McpSchema.Implementation) null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Server info must not be null");
 	}
 
 	@Test
 	void testGracefulShutdown() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").async();
+		var mcpAsyncServer = McpServer.async(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		StepVerifier.create(mcpAsyncServer.closeGracefully()).verifyComplete();
 	}
 
 	@Test
 	void testImmediateClose() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").async();
+		var mcpAsyncServer = McpServer.async(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThatCode(() -> mcpAsyncServer.close()).doesNotThrowAnyException();
 	}
@@ -117,81 +115,80 @@ public abstract class AbstractMcpAsyncServerTests {
 	@Test
 	void testAddTool() {
 		Tool newTool = new McpSchema.Tool("new-tool", "New test tool", emptyJsonSchema);
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.async();
+			.build();
 
-		StepVerifier
-			.create(mcpAsyncServer.addTool(new ToolRegistration(newTool, args -> new CallToolResult(List.of(), false))))
+		StepVerifier.create(mcpAsyncServer.addTool(new McpServerFeatures.AsyncToolRegistration(newTool,
+				args -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyComplete();
 
-		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10)));
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 	}
 
 	@Test
 	void testAddDuplicateTool() {
 		Tool duplicateTool = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema);
 
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(duplicateTool, args -> new CallToolResult(List.of(), false))
-			.async();
+			.tool(duplicateTool, args -> Mono.just(new CallToolResult(List.of(), false)))
+			.build();
 
-		StepVerifier
-			.create(mcpAsyncServer
-				.addTool(new ToolRegistration(duplicateTool, args -> new CallToolResult(List.of(), false))))
+		StepVerifier.create(mcpAsyncServer.addTool(new McpServerFeatures.AsyncToolRegistration(duplicateTool,
+				args -> Mono.just(new CallToolResult(List.of(), false)))))
 			.verifyErrorSatisfies(error -> {
 				assertThat(error).isInstanceOf(McpError.class)
 					.hasMessage("Tool with name '" + TEST_TOOL_NAME + "' already exists");
 			});
 
-		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10)));
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 	}
 
 	@Test
 	void testRemoveTool() {
 		Tool too = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema);
 
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(too, args -> new CallToolResult(List.of(), false))
-			.async();
+			.tool(too, args -> Mono.just(new CallToolResult(List.of(), false)))
+			.build();
 
 		StepVerifier.create(mcpAsyncServer.removeTool(TEST_TOOL_NAME)).verifyComplete();
 
-		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10)));
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 	}
 
 	@Test
 	void testRemoveNonexistentTool() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.async();
+			.build();
 
 		StepVerifier.create(mcpAsyncServer.removeTool("nonexistent-tool")).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(McpError.class).hasMessage("Tool with name 'nonexistent-tool' not found");
 		});
 
-		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10)));
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 	}
 
 	@Test
 	void testNotifyToolsListChanged() {
 		Tool too = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema);
 
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.tool(too, args -> new CallToolResult(List.of(), false))
-			.async();
+			.tool(too, args -> Mono.just(new CallToolResult(List.of(), false)))
+			.build();
 
 		StepVerifier.create(mcpAsyncServer.notifyToolsListChanged()).verifyComplete();
 
-		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10)));
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 	}
 
 	// ---------------------------------------
@@ -200,24 +197,24 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testNotifyResourcesListChanged() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").async();
+		var mcpAsyncServer = McpServer.async(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		StepVerifier.create(mcpAsyncServer.notifyResourcesListChanged()).verifyComplete();
 
-		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10)));
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 	}
 
 	@Test
 	void testAddResource() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
-			.async();
+			.build();
 
 		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
 				null);
-		ResourceRegistration registration = new ResourceRegistration(resource,
-				req -> new ReadResourceResult(List.of()));
+		McpServerFeatures.AsyncResourceRegistration registration = new McpServerFeatures.AsyncResourceRegistration(
+				resource, req -> Mono.just(new ReadResourceResult(List.of())));
 
 		StepVerifier.create(mcpAsyncServer.addResource(registration)).verifyComplete();
 
@@ -226,14 +223,15 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testAddResourceWithNullRegistration() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
-			.async();
+			.build();
 
-		StepVerifier.create(mcpAsyncServer.addResource(null)).verifyErrorSatisfies(error -> {
-			assertThat(error).isInstanceOf(McpError.class).hasMessage("Resource must not be null");
-		});
+		StepVerifier.create(mcpAsyncServer.addResource((McpServerFeatures.AsyncResourceRegistration) null))
+			.verifyErrorSatisfies(error -> {
+				assertThat(error).isInstanceOf(McpError.class).hasMessage("Resource must not be null");
+			});
 
 		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 	}
@@ -241,14 +239,14 @@ public abstract class AbstractMcpAsyncServerTests {
 	@Test
 	void testAddResourceWithoutCapability() {
 		// Create a server without resource capabilities
-		McpAsyncServer serverWithoutResources = McpServer.using(createMcpTransport())
+		McpAsyncServer serverWithoutResources = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
-			.async();
+			.build();
 
 		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
 				null);
-		ResourceRegistration registration = new ResourceRegistration(resource,
-				req -> new ReadResourceResult(List.of()));
+		McpServerFeatures.AsyncResourceRegistration registration = new McpServerFeatures.AsyncResourceRegistration(
+				resource, req -> Mono.just(new ReadResourceResult(List.of())));
 
 		StepVerifier.create(serverWithoutResources.addResource(registration)).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(McpError.class)
@@ -259,9 +257,9 @@ public abstract class AbstractMcpAsyncServerTests {
 	@Test
 	void testRemoveResourceWithoutCapability() {
 		// Create a server without resource capabilities
-		McpAsyncServer serverWithoutResources = McpServer.using(createMcpTransport())
+		McpAsyncServer serverWithoutResources = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
-			.async();
+			.build();
 
 		StepVerifier.create(serverWithoutResources.removeResource(TEST_RESOURCE_URI)).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(McpError.class)
@@ -275,36 +273,37 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testNotifyPromptsListChanged() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").async();
+		var mcpAsyncServer = McpServer.async(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		StepVerifier.create(mcpAsyncServer.notifyPromptsListChanged()).verifyComplete();
 
-		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10)));
+		assertThatCode(() -> mcpAsyncServer.closeGracefully().block(Duration.ofSeconds(10))).doesNotThrowAnyException();
 	}
 
 	@Test
 	void testAddPromptWithNullRegistration() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(false).build())
-			.async();
+			.build();
 
-		StepVerifier.create(mcpAsyncServer.addPrompt(null)).verifyErrorSatisfies(error -> {
-			assertThat(error).isInstanceOf(McpError.class).hasMessage("Prompt registration must not be null");
-		});
+		StepVerifier.create(mcpAsyncServer.addPrompt((McpServerFeatures.AsyncPromptRegistration) null))
+			.verifyErrorSatisfies(error -> {
+				assertThat(error).isInstanceOf(McpError.class).hasMessage("Prompt registration must not be null");
+			});
 	}
 
 	@Test
 	void testAddPromptWithoutCapability() {
 		// Create a server without prompt capabilities
-		McpAsyncServer serverWithoutPrompts = McpServer.using(createMcpTransport())
+		McpAsyncServer serverWithoutPrompts = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
-			.async();
+			.build();
 
 		Prompt prompt = new Prompt(TEST_PROMPT_NAME, "Test Prompt", List.of());
-		PromptRegistration registration = new PromptRegistration(prompt, req -> new GetPromptResult(
-				"Test prompt description",
-				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+		McpServerFeatures.AsyncPromptRegistration registration = new McpServerFeatures.AsyncPromptRegistration(prompt,
+				req -> Mono.just(new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
 
 		StepVerifier.create(serverWithoutPrompts.addPrompt(registration)).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(McpError.class)
@@ -315,9 +314,9 @@ public abstract class AbstractMcpAsyncServerTests {
 	@Test
 	void testRemovePromptWithoutCapability() {
 		// Create a server without prompt capabilities
-		McpAsyncServer serverWithoutPrompts = McpServer.using(createMcpTransport())
+		McpAsyncServer serverWithoutPrompts = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
-			.async();
+			.build();
 
 		StepVerifier.create(serverWithoutPrompts.removePrompt(TEST_PROMPT_NAME)).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(McpError.class)
@@ -330,15 +329,15 @@ public abstract class AbstractMcpAsyncServerTests {
 		String TEST_PROMPT_NAME_TO_REMOVE = "TEST_PROMPT_NAME678";
 
 		Prompt prompt = new Prompt(TEST_PROMPT_NAME_TO_REMOVE, "Test Prompt", List.of());
-		PromptRegistration registration = new PromptRegistration(prompt, req -> new GetPromptResult(
-				"Test prompt description",
-				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+		McpServerFeatures.AsyncPromptRegistration registration = new McpServerFeatures.AsyncPromptRegistration(prompt,
+				req -> Mono.just(new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content"))))));
 
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(true).build())
 			.prompts(registration)
-			.async();
+			.build();
 
 		StepVerifier.create(mcpAsyncServer.removePrompt(TEST_PROMPT_NAME_TO_REMOVE)).verifyComplete();
 
@@ -347,10 +346,10 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testRemoveNonexistentPrompt() {
-		var mcpAsyncServer2 = McpServer.using(createMcpTransport())
+		var mcpAsyncServer2 = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(true).build())
-			.async();
+			.build();
 
 		StepVerifier.create(mcpAsyncServer2.removePrompt("nonexistent-prompt")).verifyErrorSatisfies(error -> {
 			assertThat(error).isInstanceOf(McpError.class)
@@ -371,15 +370,15 @@ public abstract class AbstractMcpAsyncServerTests {
 		var rootsReceived = new McpSchema.Root[1];
 		var consumerCalled = new boolean[1];
 
-		var singleConsumerServer = McpServer.using(createMcpTransport())
+		var singleConsumerServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
-			.rootsChangeConsumers(List.of(roots -> {
+			.rootsChangeConsumers(List.of(roots -> Mono.fromRunnable(() -> {
 				consumerCalled[0] = true;
 				if (!roots.isEmpty()) {
 					rootsReceived[0] = roots.get(0);
 				}
-			}))
-			.async();
+			})))
+			.build();
 
 		assertThat(singleConsumerServer).isNotNull();
 		assertThatCode(() -> singleConsumerServer.closeGracefully().block(Duration.ofSeconds(10)))
@@ -391,13 +390,13 @@ public abstract class AbstractMcpAsyncServerTests {
 		var consumer2Called = new boolean[1];
 		var rootsContent = new List[1];
 
-		var multipleConsumersServer = McpServer.using(createMcpTransport())
+		var multipleConsumersServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
-			.rootsChangeConsumers(List.of(roots -> {
+			.rootsChangeConsumers(List.of(roots -> Mono.fromRunnable(() -> {
 				consumer1Called[0] = true;
 				rootsContent[0] = roots;
-			}, roots -> consumer2Called[0] = true))
-			.async();
+			}), roots -> Mono.fromRunnable(() -> consumer2Called[0] = true)))
+			.build();
 
 		assertThat(multipleConsumersServer).isNotNull();
 		assertThatCode(() -> multipleConsumersServer.closeGracefully().block(Duration.ofSeconds(10)))
@@ -405,12 +404,12 @@ public abstract class AbstractMcpAsyncServerTests {
 		onClose();
 
 		// Test error handling
-		var errorHandlingServer = McpServer.using(createMcpTransport())
+		var errorHandlingServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.rootsChangeConsumers(List.of(roots -> {
 				throw new RuntimeException("Test error");
 			}))
-			.async();
+			.build();
 
 		assertThat(errorHandlingServer).isNotNull();
 		assertThatCode(() -> errorHandlingServer.closeGracefully().block(Duration.ofSeconds(10)))
@@ -418,7 +417,7 @@ public abstract class AbstractMcpAsyncServerTests {
 		onClose();
 
 		// Test without consumers
-		var noConsumersServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").async();
+		var noConsumersServer = McpServer.async(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThat(noConsumersServer).isNotNull();
 		assertThatCode(() -> noConsumersServer.closeGracefully().block(Duration.ofSeconds(10)))
@@ -431,10 +430,10 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testLoggingLevels() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().logging().build())
-			.async();
+			.build();
 
 		// Test all logging levels
 		for (McpSchema.LoggingLevel level : McpSchema.LoggingLevel.values()) {
@@ -450,10 +449,10 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testLoggingWithoutCapability() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().build()) // No logging capability
-			.async();
+			.build();
 
 		var notification = McpSchema.LoggingMessageNotification.builder()
 			.level(McpSchema.LoggingLevel.INFO)
@@ -466,10 +465,10 @@ public abstract class AbstractMcpAsyncServerTests {
 
 	@Test
 	void testLoggingWithNullNotification() {
-		var mcpAsyncServer = McpServer.using(createMcpTransport())
+		var mcpAsyncServer = McpServer.async(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().logging().build())
-			.async();
+			.build();
 
 		StepVerifier.create(mcpAsyncServer.loggingNotification(null)).verifyError(McpError.class);
 	}

--- a/mcp/src/test/java/org/springframework/ai/mcp/server/AbstractMcpSyncServerTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/server/AbstractMcpSyncServerTests.java
@@ -17,15 +17,11 @@
 package org.springframework.ai.mcp.server;
 
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.ai.mcp.server.McpServer.PromptRegistration;
-import org.springframework.ai.mcp.server.McpServer.ResourceRegistration;
-import org.springframework.ai.mcp.server.McpServer.ToolRegistration;
 import org.springframework.ai.mcp.spec.McpError;
 import org.springframework.ai.mcp.spec.McpSchema;
 import org.springframework.ai.mcp.spec.McpSchema.CallToolResult;
@@ -81,31 +77,31 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testConstructorWithInvalidArguments() {
-		assertThatThrownBy(() -> McpServer.using(null)).isInstanceOf(IllegalArgumentException.class)
+		assertThatThrownBy(() -> McpServer.sync(null)).isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Transport must not be null");
 
-		assertThatThrownBy(() -> McpServer.using(createMcpTransport()).serverInfo((McpSchema.Implementation) null))
+		assertThatThrownBy(() -> McpServer.sync(createMcpTransport()).serverInfo(null))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Server info must not be null");
 	}
 
 	@Test
 	void testGracefulShutdown() {
-		var mcpSyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var mcpSyncServer = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
 	}
 
 	@Test
 	void testImmediateClose() {
-		var mcpSyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var mcpSyncServer = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThatCode(() -> mcpSyncServer.close()).doesNotThrowAnyException();
 	}
 
 	@Test
 	void testGetAsyncServer() {
-		var mcpSyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var mcpSyncServer = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThat(mcpSyncServer.getAsyncServer()).isNotNull();
 
@@ -126,14 +122,14 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testAddTool() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.sync();
+			.build();
 
 		Tool newTool = new McpSchema.Tool("new-tool", "New test tool", emptyJsonSchema);
 		assertThatCode(() -> mcpSyncServer
-			.addTool(new ToolRegistration(newTool, args -> new CallToolResult(List.of(), false))))
+			.addTool(new McpServerFeatures.SyncToolRegistration(newTool, args -> new CallToolResult(List.of(), false))))
 			.doesNotThrowAnyException();
 
 		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
@@ -143,14 +139,14 @@ public abstract class AbstractMcpSyncServerTests {
 	void testAddDuplicateTool() {
 		Tool duplicateTool = new McpSchema.Tool(TEST_TOOL_NAME, "Duplicate tool", emptyJsonSchema);
 
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tool(duplicateTool, args -> new CallToolResult(List.of(), false))
-			.sync();
+			.build();
 
-		assertThatThrownBy(() -> mcpSyncServer
-			.addTool(new ToolRegistration(duplicateTool, args -> new CallToolResult(List.of(), false))))
+		assertThatThrownBy(() -> mcpSyncServer.addTool(new McpServerFeatures.SyncToolRegistration(duplicateTool,
+				args -> new CallToolResult(List.of(), false))))
 			.isInstanceOf(McpError.class)
 			.hasMessage("Tool with name '" + TEST_TOOL_NAME + "' already exists");
 
@@ -161,11 +157,11 @@ public abstract class AbstractMcpSyncServerTests {
 	void testRemoveTool() {
 		Tool tool = new McpSchema.Tool(TEST_TOOL_NAME, "Test tool", emptyJsonSchema);
 
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
 			.tool(tool, args -> new CallToolResult(List.of(), false))
-			.sync();
+			.build();
 
 		assertThatCode(() -> mcpSyncServer.removeTool(TEST_TOOL_NAME)).doesNotThrowAnyException();
 
@@ -174,10 +170,10 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testRemoveNonexistentTool() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().tools(true).build())
-			.sync();
+			.build();
 
 		assertThatThrownBy(() -> mcpSyncServer.removeTool("nonexistent-tool")).isInstanceOf(McpError.class)
 			.hasMessage("Tool with name 'nonexistent-tool' not found");
@@ -187,7 +183,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testNotifyToolsListChanged() {
-		var mcpSyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var mcpSyncServer = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThatCode(() -> mcpSyncServer.notifyToolsListChanged()).doesNotThrowAnyException();
 
@@ -200,7 +196,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testNotifyResourcesListChanged() {
-		var mcpSyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var mcpSyncServer = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThatCode(() -> mcpSyncServer.notifyResourcesListChanged()).doesNotThrowAnyException();
 
@@ -209,15 +205,15 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testAddResource() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
-			.sync();
+			.build();
 
 		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
 				null);
-		ResourceRegistration registration = new ResourceRegistration(resource,
-				req -> new ReadResourceResult(List.of()));
+		McpServerFeatures.SyncResourceRegistration registration = new McpServerFeatures.SyncResourceRegistration(
+				resource, req -> new ReadResourceResult(List.of()));
 
 		assertThatCode(() -> mcpSyncServer.addResource(registration)).doesNotThrowAnyException();
 
@@ -226,12 +222,13 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testAddResourceWithNullRegistration() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().resources(true, false).build())
-			.sync();
+			.build();
 
-		assertThatThrownBy(() -> mcpSyncServer.addResource(null)).isInstanceOf(McpError.class)
+		assertThatThrownBy(() -> mcpSyncServer.addResource((McpServerFeatures.SyncResourceRegistration) null))
+			.isInstanceOf(McpError.class)
 			.hasMessage("Resource must not be null");
 
 		assertThatCode(() -> mcpSyncServer.closeGracefully()).doesNotThrowAnyException();
@@ -239,12 +236,12 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testAddResourceWithoutCapability() {
-		var serverWithoutResources = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var serverWithoutResources = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		Resource resource = new Resource(TEST_RESOURCE_URI, "Test Resource", "text/plain", "Test resource description",
 				null);
-		ResourceRegistration registration = new ResourceRegistration(resource,
-				req -> new ReadResourceResult(List.of()));
+		McpServerFeatures.SyncResourceRegistration registration = new McpServerFeatures.SyncResourceRegistration(
+				resource, req -> new ReadResourceResult(List.of()));
 
 		assertThatThrownBy(() -> serverWithoutResources.addResource(registration)).isInstanceOf(McpError.class)
 			.hasMessage("Server must be configured with resource capabilities");
@@ -252,7 +249,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testRemoveResourceWithoutCapability() {
-		var serverWithoutResources = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var serverWithoutResources = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThatThrownBy(() -> serverWithoutResources.removeResource(TEST_RESOURCE_URI)).isInstanceOf(McpError.class)
 			.hasMessage("Server must be configured with resource capabilities");
@@ -264,7 +261,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testNotifyPromptsListChanged() {
-		var mcpSyncServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var mcpSyncServer = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThatCode(() -> mcpSyncServer.notifyPromptsListChanged()).doesNotThrowAnyException();
 
@@ -273,23 +270,24 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testAddPromptWithNullRegistration() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(false).build())
-			.sync();
+			.build();
 
-		assertThatThrownBy(() -> mcpSyncServer.addPrompt(null)).isInstanceOf(McpError.class)
+		assertThatThrownBy(() -> mcpSyncServer.addPrompt((McpServerFeatures.SyncPromptRegistration) null))
+			.isInstanceOf(McpError.class)
 			.hasMessage("Prompt registration must not be null");
 	}
 
 	@Test
 	void testAddPromptWithoutCapability() {
-		var serverWithoutPrompts = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var serverWithoutPrompts = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		Prompt prompt = new Prompt(TEST_PROMPT_NAME, "Test Prompt", List.of());
-		PromptRegistration registration = new PromptRegistration(prompt, req -> new GetPromptResult(
-				"Test prompt description",
-				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+		McpServerFeatures.SyncPromptRegistration registration = new McpServerFeatures.SyncPromptRegistration(prompt,
+				req -> new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
 
 		assertThatThrownBy(() -> serverWithoutPrompts.addPrompt(registration)).isInstanceOf(McpError.class)
 			.hasMessage("Server must be configured with prompt capabilities");
@@ -297,7 +295,7 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testRemovePromptWithoutCapability() {
-		var serverWithoutPrompts = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var serverWithoutPrompts = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThatThrownBy(() -> serverWithoutPrompts.removePrompt(TEST_PROMPT_NAME)).isInstanceOf(McpError.class)
 			.hasMessage("Server must be configured with prompt capabilities");
@@ -306,15 +304,15 @@ public abstract class AbstractMcpSyncServerTests {
 	@Test
 	void testRemovePrompt() {
 		Prompt prompt = new Prompt(TEST_PROMPT_NAME, "Test Prompt", List.of());
-		PromptRegistration registration = new PromptRegistration(prompt, req -> new GetPromptResult(
-				"Test prompt description",
-				List.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
+		McpServerFeatures.SyncPromptRegistration registration = new McpServerFeatures.SyncPromptRegistration(prompt,
+				req -> new GetPromptResult("Test prompt description", List
+					.of(new PromptMessage(McpSchema.Role.ASSISTANT, new McpSchema.TextContent("Test content")))));
 
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(true).build())
 			.prompts(registration)
-			.sync();
+			.build();
 
 		assertThatCode(() -> mcpSyncServer.removePrompt(TEST_PROMPT_NAME)).doesNotThrowAnyException();
 
@@ -323,10 +321,10 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testRemoveNonexistentPrompt() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().prompts(true).build())
-			.sync();
+			.build();
 
 		assertThatThrownBy(() -> mcpSyncServer.removePrompt("nonexistent-prompt")).isInstanceOf(McpError.class)
 			.hasMessage("Prompt with name 'nonexistent-prompt' not found");
@@ -344,7 +342,7 @@ public abstract class AbstractMcpSyncServerTests {
 		var rootsReceived = new McpSchema.Root[1];
 		var consumerCalled = new boolean[1];
 
-		var singleConsumerServer = McpServer.using(createMcpTransport())
+		var singleConsumerServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.rootsChangeConsumers(List.of(roots -> {
 				consumerCalled[0] = true;
@@ -352,7 +350,7 @@ public abstract class AbstractMcpSyncServerTests {
 					rootsReceived[0] = roots.get(0);
 				}
 			}))
-			.sync();
+			.build();
 
 		assertThat(singleConsumerServer).isNotNull();
 		assertThatCode(() -> singleConsumerServer.closeGracefully()).doesNotThrowAnyException();
@@ -363,32 +361,32 @@ public abstract class AbstractMcpSyncServerTests {
 		var consumer2Called = new boolean[1];
 		var rootsContent = new List[1];
 
-		var multipleConsumersServer = McpServer.using(createMcpTransport())
+		var multipleConsumersServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.rootsChangeConsumers(List.of(roots -> {
 				consumer1Called[0] = true;
 				rootsContent[0] = roots;
 			}, roots -> consumer2Called[0] = true))
-			.sync();
+			.build();
 
 		assertThat(multipleConsumersServer).isNotNull();
 		assertThatCode(() -> multipleConsumersServer.closeGracefully()).doesNotThrowAnyException();
 		onClose();
 
 		// Test error handling
-		var errorHandlingServer = McpServer.using(createMcpTransport())
+		var errorHandlingServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.rootsChangeConsumers(List.of(roots -> {
 				throw new RuntimeException("Test error");
 			}))
-			.sync();
+			.build();
 
 		assertThat(errorHandlingServer).isNotNull();
 		assertThatCode(() -> errorHandlingServer.closeGracefully()).doesNotThrowAnyException();
 		onClose();
 
 		// Test without consumers
-		var noConsumersServer = McpServer.using(createMcpTransport()).serverInfo("test-server", "1.0.0").sync();
+		var noConsumersServer = McpServer.sync(createMcpTransport()).serverInfo("test-server", "1.0.0").build();
 
 		assertThat(noConsumersServer).isNotNull();
 		assertThatCode(() -> noConsumersServer.closeGracefully()).doesNotThrowAnyException();
@@ -400,10 +398,10 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testLoggingLevels() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().logging().build())
-			.sync();
+			.build();
 
 		// Test all logging levels
 		for (McpSchema.LoggingLevel level : McpSchema.LoggingLevel.values()) {
@@ -419,10 +417,10 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testLoggingWithoutCapability() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().build()) // No logging capability
-			.sync();
+			.build();
 
 		var notification = McpSchema.LoggingMessageNotification.builder()
 			.level(McpSchema.LoggingLevel.INFO)
@@ -435,10 +433,10 @@ public abstract class AbstractMcpSyncServerTests {
 
 	@Test
 	void testLoggingWithNullNotification() {
-		var mcpSyncServer = McpServer.using(createMcpTransport())
+		var mcpSyncServer = McpServer.sync(createMcpTransport())
 			.serverInfo("test-server", "1.0.0")
 			.capabilities(ServerCapabilities.builder().logging().build())
-			.sync();
+			.build();
 
 		assertThatThrownBy(() -> mcpSyncServer.loggingNotification(null)).isInstanceOf(McpError.class);
 	}

--- a/mcp/src/test/java/org/springframework/ai/mcp/spec/DefaultMcpSessionTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/spec/DefaultMcpSessionTests.java
@@ -150,7 +150,7 @@ class DefaultMcpSessionTests {
 	@Test
 	void testRequestHandling() {
 		String echoMessage = "Hello MCP!";
-		Map<String, DefaultMcpSession.RequestHandler> requestHandlers = Map.of(ECHO_METHOD,
+		Map<String, DefaultMcpSession.RequestHandler<?>> requestHandlers = Map.of(ECHO_METHOD,
 				params -> Mono.just(params));
 		transport = new MockMcpTransport();
 		session = new DefaultMcpSession(TIMEOUT, transport, requestHandlers, Map.of());


### PR DESCRIPTION
The goal of this PR is to offer means to clearly separate asynchronous, non-blocking client interaction from potentially blocking, synchronous, and imperative APIs.

It addresses issue #48 and refactors both the `McpClient` and `McpServer` sides.

The main change from the user perspective is the proposed client creation:

```java
// Synchronous client API
McpClient.sync(transport)
    ...
    .build();
```

and

```java
// Asynchronous client API
McpClient.async(transport)
    ...
    .build();
```

The server side is similar.

Also, `RequestHandler` has been made type-aware of the response. So far it used `Object`.

Deprecations:
* `McpClient#using(ClientMcpTransport)` - use `McpClient#sync(ClientMcpTransport)` or `McpClient#async(ClientMcpTransport)` instead.
* `McpClient.Builder` in favour of the above.
* `McpAsyncClient` constructor which accepted non-reactive types.
* TODO: list server side changes