### PR TITLE
feat: Add protocol version negotiation

### DIFF
--- a/mcp/src/main/java/org/springframework/ai/mcp/client/McpClientFeatures.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/client/McpClientFeatures.java
@@ -67,7 +67,6 @@ class McpClientFeatures {
 
 		/**
 		 * Create an instance and validate the arguments.
-		 * @param clientInfo the client implementation information.
 		 * @param clientCapabilities the client capabilities.
 		 * @param roots the roots.
 		 * @param toolsChangeConsumers the tools change consumers.
@@ -85,7 +84,6 @@ class McpClientFeatures {
 				Function<McpSchema.CreateMessageRequest, Mono<McpSchema.CreateMessageResult>> samplingHandler) {
 
 			Assert.notNull(clientInfo, "Client info must not be null");
-
 			this.clientInfo = clientInfo;
 			this.clientCapabilities = (clientCapabilities != null) ? clientCapabilities
 					: new McpSchema.ClientCapabilities(null,
@@ -182,7 +180,6 @@ class McpClientFeatures {
 				Function<McpSchema.CreateMessageRequest, McpSchema.CreateMessageResult> samplingHandler) {
 
 			Assert.notNull(clientInfo, "Client info must not be null");
-
 			this.clientInfo = clientInfo;
 			this.clientCapabilities = (clientCapabilities != null) ? clientCapabilities
 					: new McpSchema.ClientCapabilities(null,

--- a/mcp/src/main/java/org/springframework/ai/mcp/util/Assert.java
+++ b/mcp/src/main/java/org/springframework/ai/mcp/util/Assert.java
@@ -16,11 +16,13 @@
 
 package org.springframework.ai.mcp.util;
 
+import java.util.Collection;
+
 import reactor.util.annotation.Nullable;
 
 /**
  * Assertion utility class that assists in validating arguments.
- * 
+ *
  * @author Christian Tzolov
  */
 
@@ -28,6 +30,18 @@ import reactor.util.annotation.Nullable;
  * Utility class providing assertion methods for parameter validation.
  */
 public final class Assert {
+
+	/**
+	 * Assert that the collection is not {@code null} and not empty.
+	 * @param collection the collection to check
+	 * @param message the exception message to use if the assertion fails
+	 * @throws IllegalArgumentException if the collection is {@code null} or empty
+	 */
+	public static void notEmpty(@Nullable Collection<?> collection, String message) {
+		if (collection == null || collection.isEmpty()) {
+			throw new IllegalArgumentException(message);
+		}
+	}
 
 	/**
 	 * Assert that an object is not {@code null}.

--- a/mcp/src/test/java/org/springframework/ai/mcp/MockMcpTransport.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/MockMcpTransport.java
@@ -32,7 +32,10 @@ import org.springframework.ai.mcp.spec.McpSchema.JSONRPCNotification;
 import org.springframework.ai.mcp.spec.McpSchema.JSONRPCRequest;
 import org.springframework.ai.mcp.spec.ServerMcpTransport;
 
-@SuppressWarnings("unused")
+/**
+ * A mock implementation of the {@link ClientMcpTransport} and {@link ServerMcpTransport}
+ * interfaces.
+ */
 public class MockMcpTransport implements ClientMcpTransport, ServerMcpTransport {
 
 	private final AtomicInteger inboundMessageCount = new AtomicInteger(0);
@@ -91,6 +94,7 @@ public class MockMcpTransport implements ClientMcpTransport, ServerMcpTransport 
 			connected = false;
 			outgoing.tryEmitComplete();
 			inbound.tryEmitComplete();
+			// Wait for all subscribers to complete
 			return Mono.empty();
 		});
 	}

--- a/mcp/src/test/java/org/springframework/ai/mcp/client/McpAsyncClientResponseHandlerTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/client/McpAsyncClientResponseHandlerTests.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/mcp/src/test/java/org/springframework/ai/mcp/client/McpClientProtocolVersionTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/client/McpClientProtocolVersionTests.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.client;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.ai.mcp.MockMcpTransport;
+import org.springframework.ai.mcp.spec.McpError;
+import org.springframework.ai.mcp.spec.McpSchema;
+import org.springframework.ai.mcp.spec.McpSchema.InitializeResult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for MCP protocol version negotiation and compatibility.
+ */
+class McpClientProtocolVersionTests {
+
+	private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
+
+	private static final McpSchema.Implementation CLIENT_INFO = new McpSchema.Implementation("test-client", "1.0.0");
+
+	@Test
+	void shouldUseLatestVersionByDefault() {
+		MockMcpTransport transport = new MockMcpTransport();
+		McpAsyncClient client = McpClient.async(transport)
+			.clientInfo(CLIENT_INFO)
+			.requestTimeout(REQUEST_TIMEOUT)
+			.build();
+
+		try {
+			Mono<InitializeResult> initializeResultMono = client.initialize();
+
+			StepVerifier.create(initializeResultMono).then(() -> {
+				McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
+				assertThat(request.params()).isInstanceOf(McpSchema.InitializeRequest.class);
+				McpSchema.InitializeRequest initRequest = (McpSchema.InitializeRequest) request.params();
+				assertThat(initRequest.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+
+				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
+						new McpSchema.InitializeResult(McpSchema.LATEST_PROTOCOL_VERSION, null,
+								new McpSchema.Implementation("test-server", "1.0.0"), null),
+						null));
+			}).assertNext(result -> {
+				assertThat(result.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+			}).verifyComplete();
+
+		}
+		finally {
+			// Ensure cleanup happens even if test fails
+			StepVerifier.create(client.closeGracefully()).verifyComplete();
+		}
+	}
+
+	@Test
+	void shouldNegotiateSpecificVersion() {
+		String oldVersion = "0.1.0";
+		MockMcpTransport transport = new MockMcpTransport();
+		McpAsyncClient client = McpClient.async(transport)
+			.clientInfo(CLIENT_INFO)
+			.requestTimeout(REQUEST_TIMEOUT)
+			.build();
+
+		client.setProtocolVersions(List.of(oldVersion, McpSchema.LATEST_PROTOCOL_VERSION));
+
+		try {
+			Mono<InitializeResult> initializeResultMono = client.initialize();
+
+			StepVerifier.create(initializeResultMono).then(() -> {
+				McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
+				assertThat(request.params()).isInstanceOf(McpSchema.InitializeRequest.class);
+				McpSchema.InitializeRequest initRequest = (McpSchema.InitializeRequest) request.params();
+				assertThat(initRequest.protocolVersion()).isIn(List.of(oldVersion, McpSchema.LATEST_PROTOCOL_VERSION));
+
+				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
+						new McpSchema.InitializeResult(oldVersion, null,
+								new McpSchema.Implementation("test-server", "1.0.0"), null),
+						null));
+			}).assertNext(result -> {
+				assertThat(result.protocolVersion()).isEqualTo(oldVersion);
+			}).verifyComplete();
+		}
+		finally {
+			StepVerifier.create(client.closeGracefully()).verifyComplete();
+		}
+	}
+
+	@Test
+	void shouldFailForUnsupportedVersion() {
+		String unsupportedVersion = "999.999.999";
+		MockMcpTransport transport = new MockMcpTransport();
+		McpAsyncClient client = McpClient.async(transport)
+			.clientInfo(CLIENT_INFO)
+			.requestTimeout(REQUEST_TIMEOUT)
+			.build();
+
+		try {
+			Mono<InitializeResult> initializeResultMono = client.initialize();
+
+			StepVerifier.create(initializeResultMono).then(() -> {
+				McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
+				assertThat(request.params()).isInstanceOf(McpSchema.InitializeRequest.class);
+
+				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
+						new McpSchema.InitializeResult(unsupportedVersion, null,
+								new McpSchema.Implementation("test-server", "1.0.0"), null),
+						null));
+			}).expectError(McpError.class).verify();
+		}
+		finally {
+			StepVerifier.create(client.closeGracefully()).verifyComplete();
+		}
+	}
+
+	@Test
+	void shouldUseHighestVersionWhenMultipleSupported() {
+		String oldVersion = "0.1.0";
+		String middleVersion = "0.2.0";
+		String latestVersion = McpSchema.LATEST_PROTOCOL_VERSION;
+
+		MockMcpTransport transport = new MockMcpTransport();
+		McpAsyncClient client = McpClient.async(transport)
+			.clientInfo(CLIENT_INFO)
+			.requestTimeout(REQUEST_TIMEOUT)
+			.build();
+
+		client.setProtocolVersions(List.of(oldVersion, middleVersion, latestVersion));
+
+		try {
+			Mono<InitializeResult> initializeResultMono = client.initialize();
+
+			StepVerifier.create(initializeResultMono).then(() -> {
+				McpSchema.JSONRPCRequest request = transport.getLastSentMessageAsRequest();
+				McpSchema.InitializeRequest initRequest = (McpSchema.InitializeRequest) request.params();
+				assertThat(initRequest.protocolVersion()).isEqualTo(latestVersion);
+
+				transport.simulateIncomingMessage(new McpSchema.JSONRPCResponse(McpSchema.JSONRPC_VERSION, request.id(),
+						new McpSchema.InitializeResult(latestVersion, null,
+								new McpSchema.Implementation("test-server", "1.0.0"), null),
+						null));
+			}).assertNext(result -> {
+				assertThat(result.protocolVersion()).isEqualTo(latestVersion);
+			}).verifyComplete();
+		}
+		finally {
+			StepVerifier.create(client.closeGracefully()).verifyComplete();
+		}
+
+	}
+
+}

--- a/mcp/src/test/java/org/springframework/ai/mcp/server/McpServerProtocolVersionTests.java
+++ b/mcp/src/test/java/org/springframework/ai/mcp/server/McpServerProtocolVersionTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.ai.mcp.server;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.ai.mcp.MockMcpTransport;
+import org.springframework.ai.mcp.spec.McpSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for MCP server protocol version negotiation and compatibility.
+ */
+class McpServerProtocolVersionTests {
+
+	private static final McpSchema.Implementation SERVER_INFO = new McpSchema.Implementation("test-server", "1.0.0");
+
+	private static final McpSchema.Implementation CLIENT_INFO = new McpSchema.Implementation("test-client", "1.0.0");
+
+	private McpSchema.JSONRPCRequest jsonRpcInitializeRequest(String requestId, String protocolVersion) {
+		return new McpSchema.JSONRPCRequest(McpSchema.JSONRPC_VERSION, McpSchema.METHOD_INITIALIZE, requestId,
+				new McpSchema.InitializeRequest(protocolVersion, null, CLIENT_INFO));
+	}
+
+	@Test
+	void shouldUseLatestVersionByDefault() {
+		MockMcpTransport transport = new MockMcpTransport();
+		McpAsyncServer server = McpServer.async(transport).serverInfo(SERVER_INFO).build();
+
+		String requestId = UUID.randomUUID().toString();
+
+		transport.simulateIncomingMessage(jsonRpcInitializeRequest(requestId, McpSchema.LATEST_PROTOCOL_VERSION));
+
+		McpSchema.JSONRPCMessage response = transport.getLastSentMessage();
+		assertThat(response).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		McpSchema.JSONRPCResponse jsonResponse = (McpSchema.JSONRPCResponse) response;
+		assertThat(jsonResponse.id()).isEqualTo(requestId);
+		assertThat(jsonResponse.result()).isInstanceOf(McpSchema.InitializeResult.class);
+		McpSchema.InitializeResult result = (McpSchema.InitializeResult) jsonResponse.result();
+		assertThat(result.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+
+		server.closeGracefully().subscribe();
+	}
+
+	@Test
+	void shouldNegotiateSpecificVersion() {
+		String oldVersion = "0.1.0";
+		MockMcpTransport transport = new MockMcpTransport();
+		McpAsyncServer server = McpServer.async(transport).serverInfo(SERVER_INFO).build();
+
+		server.setProtocolVersions(List.of(oldVersion, McpSchema.LATEST_PROTOCOL_VERSION));
+
+		String requestId = UUID.randomUUID().toString();
+
+		transport.simulateIncomingMessage(jsonRpcInitializeRequest(requestId, oldVersion));
+
+		McpSchema.JSONRPCMessage response = transport.getLastSentMessage();
+		assertThat(response).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		McpSchema.JSONRPCResponse jsonResponse = (McpSchema.JSONRPCResponse) response;
+		assertThat(jsonResponse.id()).isEqualTo(requestId);
+		assertThat(jsonResponse.result()).isInstanceOf(McpSchema.InitializeResult.class);
+		McpSchema.InitializeResult result = (McpSchema.InitializeResult) jsonResponse.result();
+		assertThat(result.protocolVersion()).isEqualTo(oldVersion);
+
+		server.closeGracefully().subscribe();
+	}
+
+	@Test
+	void shouldSuggestLatestVersionForUnsupportedVersion() {
+		String unsupportedVersion = "999.999.999";
+		MockMcpTransport transport = new MockMcpTransport();
+		McpAsyncServer server = McpServer.async(transport).serverInfo(SERVER_INFO).build();
+
+		String requestId = UUID.randomUUID().toString();
+
+		transport.simulateIncomingMessage(jsonRpcInitializeRequest(requestId, unsupportedVersion));
+
+		McpSchema.JSONRPCMessage response = transport.getLastSentMessage();
+		assertThat(response).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		McpSchema.JSONRPCResponse jsonResponse = (McpSchema.JSONRPCResponse) response;
+		assertThat(jsonResponse.id()).isEqualTo(requestId);
+		assertThat(jsonResponse.result()).isInstanceOf(McpSchema.InitializeResult.class);
+		McpSchema.InitializeResult result = (McpSchema.InitializeResult) jsonResponse.result();
+		assertThat(result.protocolVersion()).isEqualTo(McpSchema.LATEST_PROTOCOL_VERSION);
+
+		server.closeGracefully().subscribe();
+	}
+
+	@Test
+	void shouldUseHighestVersionWhenMultipleSupported() {
+		String oldVersion = "0.1.0";
+		String middleVersion = "0.2.0";
+		String latestVersion = McpSchema.LATEST_PROTOCOL_VERSION;
+
+		MockMcpTransport transport = new MockMcpTransport();
+		McpAsyncServer server = McpServer.async(transport).serverInfo(SERVER_INFO).build();
+
+		server.setProtocolVersions(List.of(oldVersion, middleVersion, latestVersion));
+
+		String requestId = UUID.randomUUID().toString();
+		transport.simulateIncomingMessage(jsonRpcInitializeRequest(requestId, latestVersion));
+
+		McpSchema.JSONRPCMessage response = transport.getLastSentMessage();
+		assertThat(response).isInstanceOf(McpSchema.JSONRPCResponse.class);
+		McpSchema.JSONRPCResponse jsonResponse = (McpSchema.JSONRPCResponse) response;
+		assertThat(jsonResponse.id()).isEqualTo(requestId);
+		assertThat(jsonResponse.result()).isInstanceOf(McpSchema.InitializeResult.class);
+		McpSchema.InitializeResult result = (McpSchema.InitializeResult) jsonResponse.result();
+		assertThat(result.protocolVersion()).isEqualTo(latestVersion);
+
+		server.closeGracefully().subscribe();
+	}
+
+}


### PR DESCRIPTION
Implement protocol version negotiation between MCP client and server to ensure compatibility and graceful version handling.
The server will now suggest the latest supported version when an unsupported version is requested, while the client will verify version compatibility during initialization.

- Support multiple protocol versions in both client and server
- Negotiate compatible version during initialization
- Fall back to latest version when unsupported version requested
- Add comprehensive test coverage for version negotiation

Resolves #71